### PR TITLE
Idea: use `ruff` as a replacement for `flake8` + `isort` ?

### DIFF
--- a/.github/pages/make_switcher.py
+++ b/.github/pages/make_switcher.py
@@ -59,7 +59,7 @@ def get_versions(ref: str, add: Optional[str], remove: Optional[str]) -> List[st
 def write_json(path: Path, repository: str, versions: str):
     org, repo_name = repository.split("/")
     struct = [
-        dict(name=version, url=f"https://{org}.github.io/{repo_name}/{version}/")
+        {"name": version, "url": f"https://{org}.github.io/{repo_name}/{version}/"}
         for version in versions
     ]
     text = json.dumps(struct, indent=2)

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -7,33 +7,26 @@ on:
     # Run every Monday at 8am to check latest versions of dependencies
     - cron: "0 8 * * WED"
 
-
 jobs:
   lint:
-     # pull requests are a duplicate of a branch push if within the same repo.
-     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-     runs-on: ubuntu-latest
-     steps:
-        - name: Setup Python
-          uses: actions/setup-python@v4
-          with:
-            python-version: '3.10'
-            architecture: x64
+    # pull requests are a duplicate of a branch push if within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          architecture: x64
 
+      - name: Checkout Hyperion
+        uses: actions/checkout@v3
 
-        - name: Checkout Hyperion
-          uses: actions/checkout@v3
+      - name: Install ruff
+        run: pip install ruff
 
-
-        - name: Install flake8
-          run: pip install flake8
-
-
-        - name: Run flake8
-          uses: TrueBrain/actions-flake8@v2
-          with:
-            path: src
-
+      - name: Run ruff
+        run: ruff .
 
   tests:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
@@ -42,20 +35,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
-
+          python-version: "3.10"
 
       - name: Install with latest dependencies
         run: pip install -e .[dev]
 
-
       - name: Run tests
         run: pytest --random-order -m "not (dlstbx or s03)"
-
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,8 @@ dmypy.json
 # Log files
 /tmp
 
+# further build artifacts
+lockfiles/
+
+# ruff cache
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,4 @@
 repos:
-  # Automatically sort imports
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
   # Automatic source code formatting
   - repo: https://github.com/psf/black
     rev: 22.3.0
@@ -14,13 +7,6 @@ repos:
         args: [--safe, --quiet]
         files: \.pyi?$|SConscript$|^libtbx_config$
         types: [file]
-
-  # Linting
-  - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
-    hooks:
-      - id: flake8
-        additional_dependencies: ["flake8-comprehensions==3.5.0"]
 
   # Give a specific warning for added image files
   - repo: local
@@ -32,6 +18,13 @@ repos:
           https://github.com/dials/dials.github.io
         language: fail
         files: '.*\.png$'
+
+      - id: ruff
+        name: Run ruff
+        stages: [commit]
+        language: system
+        entry: ruff
+        types: [python]
 
   # Syntax validation and some basic sanity checks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.remote-containers",
+        "ms-python.python",
+        "tamasfe.even-better-toml",
+        "redhat.vscode-yaml",
+        "ryanluker.vscode-coverage-gutters",
+        "charliermarsh.Ruff"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Enabled": false,
     "python.linting.mypyEnabled": true,
     "python.linting.enabled": true,
     "python.testing.pytestArgs": [],
@@ -10,18 +10,15 @@
     "python.analysis.autoImportCompletions": true,
     "python.languageServer": "Pylance",
     "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-        "source.organizeImports": true
-    },
-    "python.sortImports.args": [
-        "--profile",
-        "black"
-    ],
     "python.defaultInterpreterPath": ".venv/bin/python",
     "[python]": {
         "editor.rulers": [
             88
-        ]
+        ],
+        "editor.codeActionsOnSave": {
+            "source.fixAll.ruff": false,
+            "source.organizeImports.ruff": true
+        }
     },
     "terminal.integrated.gpuAcceleration": "off",
     "python.analysis.typeCheckingMode": "basic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,16 @@ markers = [
 ]
 addopts = "--cov=src/hyperion --cov-report term --cov-report xml:cov.xml"
 testpaths = "src"
+
+
+[tool.ruff]
+src = ["src", "tests"]
+line-length = 88
+ignore = ["C408", "E501", "F811"]
+select = [
+    "C4",   # flake8-comprehensions - https://beta.ruff.rs/docs/rules/#flake8-comprehensions-c4
+    "E",    # pycodestyle errors - https://beta.ruff.rs/docs/rules/#error-e
+    "F",    # pyflakes rules - https://beta.ruff.rs/docs/rules/#pyflakes-f
+    "W",    # pycodestyle warnings - https://beta.ruff.rs/docs/rules/#warning-w
+    "I001", # isort
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     xarray
     doct
     databroker
-    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git@e4963b4749d0c75ec16b5d6d0b67ac115757e772
+    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git@af63f5cf6742e094faac298396e2c16b422bcc8e
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
 
 
@@ -44,17 +44,16 @@ install_requires =
 dev =
     GitPython
     black
-    isort>5.0
     pytest-cov
     pytest-random-order
     ipython
     mockito
     pre-commit
-    flake8
     mypy
     matplotlib
     tox
     build
+    ruff
 
 [options.packages.find]
 where = src
@@ -69,20 +68,3 @@ ignore_missing_imports = True
 namespace_packages = true
 [mypy-opentelemetry.sdk.*]
 implicit_reexport = True
-
-[isort]
-profile=black
-float_to_top=true
-
-[flake8]
-max-line-length = 88
-extend-ignore =
-    # See https://github.com/PyCQA/pycodestyle/issues/373
-    E203,
-    # support typing.overload decorator
-    F811,
-    # line too long
-    E501,
-    # Ignore calls to dict()/tuple() instead of using {}/()
-    C408,
-

--- a/src/hyperion/system_tests/test_fgs_plan.py
+++ b/src/hyperion/system_tests/test_fgs_plan.py
@@ -23,9 +23,8 @@ from hyperion.external_interaction.system_tests.conftest import (  # noqa
     zocalo_env,
 )
 from hyperion.parameters.beamline_parameters import GDABeamlineParameters
-from hyperion.parameters.constants import BEAMLINE_PARAMETER_PATHS
+from hyperion.parameters.constants import BEAMLINE_PARAMETER_PATHS, SIM_BEAMLINE
 from hyperion.parameters.constants import DEV_ISPYB_DATABASE_CFG as ISPYB_CONFIG
-from hyperion.parameters.constants import SIM_BEAMLINE
 from hyperion.parameters.external_parameters import from_file as default_raw_params
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,


### PR DESCRIPTION
Test for adding `ruff` as a replacement for `flake8` + `isort`.

Main advantage is speed (approx 100x faster):

```
$ time isort --check .

real	0m0.420s
user	0m0.349s
sys	0m0.040s

$ time flake8 src/

real	0m0.859s
user	0m2.157s
sys	0m0.154s

$ time ruff .

real	0m0.011s
user	0m0.006s
sys	0m0.006s
```

One code change is required due to a difference in opinion between ruff and `isort` about constructs like:

```python
from somewhere import thing1
from somewhere import thing2 as aliased_name
from somewhere import thing3
```
which ruff prefers formatted as:
```python
from somewhere import thing1, thing3
from somewhere import thing2 as aliased_name
```

Other than that it is a 1:1 replacement in terms of linting rules.

This seems to be the direction a lot of modern python projects are moving in, and a better dev experience with `pre-commit` etc is always nice.