### PR TITLE
913 flux is not being read from hardware

### DIFF
--- a/src/hyperion/experiment_plans/tests/test_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/tests/test_flyscan_xray_centre_plan.py
@@ -156,6 +156,7 @@ def test_results_adjusted_and_passed_to_move_xyz(
                 "s4_slit_gaps_xgap": 0,
                 "s4_slit_gaps_ygap": 0,
                 "attenuator_actual_transmission": 0,
+                "flux_flux_reading": 10,
             },
         }
     )
@@ -278,6 +279,7 @@ def test_individual_plans_triggered_once_and_only_once_in_composite_run(
                 "s4_slit_gaps_xgap": 0,
                 "s4_slit_gaps_ygap": 0,
                 "attenuator_actual_transmission": 0,
+                "flux_flux_reading": 10,
             },
         }
     )
@@ -327,6 +329,7 @@ def test_logging_within_plan(
                 "s4_slit_gaps_xgap": 0,
                 "s4_slit_gaps_ygap": 0,
                 "attenuator_actual_transmission": 0,
+                "flux_flux_reading": 10,
             },
         }
     )

--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -68,6 +68,9 @@ class BaseISPyBCallback(CallbackBase):
             self.params.hyperion_params.ispyb_params.transmission_fraction = doc[
                 "data"
             ]["attenuator_actual_transmission"]
+            self.params.hyperion_params.ispyb_params.flux = doc["data"][
+                "flux_flux_reading"
+            ]
 
             LOGGER.info("Creating ispyb entry.")
             self.ispyb_ids = self.ispyb.begin_deposition()

--- a/src/hyperion/external_interaction/callbacks/xray_centre/tests/conftest.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/tests/conftest.py
@@ -97,6 +97,7 @@ class TestData:
             "synchrotron_machine_status_synchrotron_mode": "test",
             "undulator_gap": 1.234,
             "attenuator_actual_transmission": 1,
+            "flux_flux_reading": 10,
         },
         "timestamps": {"det1": 1666604299.8220396, "det2": 1666604299.8235943},
         "seq_num": 1,


### PR DESCRIPTION
Fixes #913
Added `flux_flux_reading` into **test_flyscan_xray_centre_plan.py** mock subscriptions and **ispyb_callback_base.py** so flux can be properly read.



### To test:
1. Run tests
