### PR TITLE
Remove uninstall of dodal as it happens on re-install

### DIFF
--- a/dls_dev_env.sh
+++ b/dls_dev_env.sh
@@ -21,7 +21,6 @@ if [ ! -d "../dodal" ]; then
   git clone git@github.com:DiamondLightSource/dodal.git ../dodal
 fi
 
-pip uninstall -y dodal
 pip install -e ../dodal[dev]
 
 # get dlstbx into our env


### PR DESCRIPTION
Fixes #892

### To test:
1. Run `./dls_dev_env.sh` on main, confirm you get a warning of `WARNING: Skipping dodal as it is not installed.`
2. Do the same on this branch, confirm no warning and that Hyperion is correctly using your local version of `dodal` by doing a `pip list`
