### PR TITLE
Write end_time_estimated in nexus file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hyperion
-description = Unattended MX data collection using BlueSky / Ophyd 
+description = Unattended MX data collection using BlueSky / Ophyd
 url = https://github.com/DiamondLightSource/hyperion
 license = BSD 3-Clause License
 long_description = file: README.rst
@@ -25,7 +25,7 @@ install_requires =
     ispyb
     scanspec
     numpy
-    nexgen @ git+https://github.com/dials/nexgen.git@a1e67fbbf485f336780f24adba0c31995c40d173
+    nexgen @ git+https://github.com/dials/nexgen.git@db4858f6d91a3d07c6c0f815ef752849c0bf79d4
     opentelemetry-distro
     opentelemetry-exporter-jaeger
     ophyd

--- a/src/hyperion/experiment_plans/tests/test_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/tests/test_flyscan_xray_centre_plan.py
@@ -404,9 +404,6 @@ def test_when_grid_scan_ran_then_eiger_disarmed_before_zocalo_end(
     ), patch(
         "hyperion.external_interaction.callbacks.xray_centre.nexus_callback.NexusWriter.create_nexus_file",
         autospec=True,
-    ), patch(
-        "hyperion.external_interaction.callbacks.xray_centre.nexus_callback.NexusWriter.update_nexus_file_timestamp",
-        autospec=True,
     ):
         RE(flyscan_xray_centre(test_fgs_params))
 

--- a/src/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
@@ -44,12 +44,3 @@ class RotationNexusFileCallback(CallbackBase):
                 self.parameters.get_data_shape(),
             )
             self.writer.create_nexus_file()
-
-    def stop(self, doc: dict):
-        if self.run_uid is not None and doc.get("run_start") == self.run_uid:
-            LOGGER.info("Finalising nexus file.")
-            LOGGER.info("Updating Nexus file timestamps.")
-            assert (
-                self.writer is not None
-            ), "Failed to update Nexus file timestamp, writer was not initialised."
-            self.writer.update_nexus_file_timestamp()

--- a/src/hyperion/external_interaction/callbacks/rotation/tests/test_rotation_callbacks.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/tests/test_rotation_callbacks.py
@@ -66,7 +66,6 @@ def test_nexus_handler_gets_documents_in_mock_plan(
     ):
         cb = RotationCallbackCollection.from_params(params)
     cb.nexus_handler.start = MagicMock(autospec=True)
-    cb.nexus_handler.stop = MagicMock(autospec=True)
     cb.ispyb_handler.start = MagicMock(autospec=True)
     cb.ispyb_handler.stop = MagicMock(autospec=True)
 
@@ -77,7 +76,6 @@ def test_nexus_handler_gets_documents_in_mock_plan(
     assert call_content_outer["hyperion_internal_parameters"] == params.json()
     call_content_inner = cb.nexus_handler.start.call_args_list[1].args[0]
     assert call_content_inner["subplan_name"] == "rotation_scan_main"
-    assert cb.nexus_handler.stop.call_count == 2
 
 
 @patch(
@@ -138,7 +136,6 @@ def test_zocalo_start_and_end_triggered_once(
     cb = RotationCallbackCollection.from_params(params)
 
     cb.nexus_handler.start = MagicMock(autospec=True)
-    cb.nexus_handler.stop = MagicMock(autospec=True)
     cb.ispyb_handler.start = MagicMock(autospec=True)
     cb.ispyb_handler.stop = MagicMock(autospec=True)
     cb.ispyb_handler.ispyb_ids = [0]
@@ -162,7 +159,6 @@ def test_zocalo_start_and_end_not_triggered_if_ispyb_ids_not_present(
     cb = RotationCallbackCollection.from_params(params)
 
     cb.nexus_handler.start = MagicMock(autospec=True)
-    cb.nexus_handler.stop = MagicMock(autospec=True)
     cb.ispyb_handler.start = MagicMock(autospec=True)
     cb.ispyb_handler.stop = MagicMock(autospec=True)
     with pytest.raises(ISPyBDepositionNotMade):

--- a/src/hyperion/external_interaction/callbacks/xray_centre/nexus_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/nexus_callback.py
@@ -64,15 +64,3 @@ class GridscanNexusFileCallback(CallbackBase):
             )
             self.nexus_writer_1.create_nexus_file()
             self.nexus_writer_2.create_nexus_file()
-
-    def stop(self, doc: dict):
-        if (
-            self.run_start_uid is not None
-            and doc.get("run_start") == self.run_start_uid
-        ):
-            LOGGER.info("Updating Nexus file timestamps.")
-            assert (
-                self.nexus_writer_1 is not None and self.nexus_writer_2 is not None
-            ), "Failed to update Nexus file timestamps, writers were not initialised."
-            self.nexus_writer_1.update_nexus_file_timestamp()
-            self.nexus_writer_2.update_nexus_file_timestamp()

--- a/src/hyperion/external_interaction/callbacks/xray_centre/tests/test_nexus_handler.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/tests/test_nexus_handler.py
@@ -122,18 +122,3 @@ def test_sensible_error_if_writing_triggered_before_params_received(
         )
 
     assert "Nexus callback did not receive parameters" in excinfo.value.args[0]
-
-
-def test_sensible_error_stop_triggered_before_writing(
-    nexus_writer: MagicMock, dummy_params
-):
-    nexus_handler = GridscanNexusFileCallback()
-    nexus_handler.run_start_uid = "test_run"
-    with pytest.raises(AssertionError) as excinfo:
-        nexus_handler.stop(
-            {
-                "run_start": "test_run",
-            }
-        )
-
-    assert "Failed to update Nexus file timestamps" in excinfo.value.args[0]

--- a/src/hyperion/external_interaction/nexus/nexus_utils.py
+++ b/src/hyperion/external_interaction/nexus/nexus_utils.py
@@ -64,11 +64,10 @@ def create_goniometer_axes(
 
 
 def get_start_and_predicted_end_time(time_expected: float) -> tuple[str, str]:
+    time_format = r"%Y-%m-%dT%H:%M:%SZ"
     start = datetime.utcfromtimestamp(time.time())
     end_est = start + timedelta(seconds=time_expected)
-    return start.strftime(r"%Y-%m-%dT%H:%M:%SZ"), end_est.strftime(
-        r"%Y-%m-%dT%H:%M:%SZ"
-    )
+    return start.strftime(time_format), end_est.strftime(time_format)
 
 
 def create_detector_parameters(detector_params: DetectorParams) -> Detector:

--- a/src/hyperion/external_interaction/nexus/nexus_utils.py
+++ b/src/hyperion/external_interaction/nexus/nexus_utils.py
@@ -63,13 +63,12 @@ def create_goniometer_axes(
     return Goniometer(gonio_axes, scan_points)
 
 
-def get_current_time():
-    return datetime.utcfromtimestamp(time.time()).strftime(r"%Y-%m-%dT%H:%M:%SZ")
-
-
-def get_predicted_end_time(start: str, delta: float):
-    end = datetime.strptime(start, r"%Y-%m-%dT%H:%M:%SZ") + timedelta(seconds=delta)
-    return end.strftime(r"%Y-%m-%dT%H:%M:%SZ")
+def get_start_and_predicted_end_time(time_expected: float) -> tuple[str, str]:
+    start = datetime.utcfromtimestamp(time.time())
+    end_est = start + timedelta(seconds=time_expected)
+    return start.strftime(r"%Y-%m-%dT%H:%M:%SZ"), end_est.strftime(
+        r"%Y-%m-%dT%H:%M:%SZ"
+    )
 
 
 def create_detector_parameters(detector_params: DetectorParams) -> Detector:

--- a/src/hyperion/external_interaction/nexus/nexus_utils.py
+++ b/src/hyperion/external_interaction/nexus/nexus_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from dodal.devices.detector import DetectorParams
 from nexgen.nxs_utils import Attenuator, Axis, Beam, Detector, EigerDetector, Goniometer
@@ -65,6 +65,11 @@ def create_goniometer_axes(
 
 def get_current_time():
     return datetime.utcfromtimestamp(time.time()).strftime(r"%Y-%m-%dT%H:%M:%SZ")
+
+
+def get_predicted_end_time(start: str, delta: float):
+    end = datetime.strptime(start, r"%Y-%m-%dT%H:%M:%SZ") + timedelta(seconds=delta)
+    return end.strftime(r"%Y-%m-%dT%H:%M:%SZ")
 
 
 def create_detector_parameters(detector_params: DetectorParams) -> Detector:

--- a/src/hyperion/external_interaction/nexus/write_nexus.py
+++ b/src/hyperion/external_interaction/nexus/write_nexus.py
@@ -18,6 +18,7 @@ from hyperion.external_interaction.nexus.nexus_utils import (
     create_detector_parameters,
     create_goniometer_axes,
     get_current_time,
+    get_predicted_end_time,
 )
 from hyperion.parameters.internal_parameters import InternalParameters
 
@@ -79,6 +80,9 @@ class NexusWriter:
         initialised.
         """
         start_time = get_current_time()
+        est_end_time = get_predicted_end_time(
+            start_time, self.detector.exp_time * self.full_num_of_images
+        )
 
         vds_shape = self.data_shape
 
@@ -95,6 +99,7 @@ class NexusWriter:
             NXmx_Writer.write(
                 image_filename=f"{self.full_filename}",
                 start_time=start_time,
+                est_end_time=est_end_time,
             )
             NXmx_Writer.write_vds(
                 vds_offset=self.start_index,

--- a/src/hyperion/external_interaction/nexus/write_nexus.py
+++ b/src/hyperion/external_interaction/nexus/write_nexus.py
@@ -5,11 +5,8 @@ gridscan.
 from __future__ import annotations
 
 import math
-import shutil
 from pathlib import Path
 
-import h5py
-import numpy as np
 from nexgen.nxs_utils import Detector, Goniometer, Source
 from nexgen.nxs_write.NXmxWriter import NXmxFileWriter
 
@@ -105,21 +102,6 @@ class NexusWriter:
                 vds_offset=self.start_index,
                 vds_shape=vds_shape,
             )
-
-    def update_nexus_file_timestamp(self):
-        """
-        Write timestamp when finishing run.
-        For the nexus file to be updated atomically, changes are written to a
-        temporary copy which then replaces the original.
-        """
-        for filename in [self.nexus_file, self.master_file]:
-            temp_filename = filename.parent / f"{filename.name}.tmp"
-            shutil.copy(filename, temp_filename)
-            with h5py.File(temp_filename, "r+") as nxsfile:
-                nxsfile["entry"].create_dataset(
-                    "end_time", data=np.string_(get_current_time())
-                )
-            shutil.move(temp_filename, filename)
 
     def get_image_datafiles(self, max_images_per_file=1000):
         return [

--- a/src/hyperion/external_interaction/nexus/write_nexus.py
+++ b/src/hyperion/external_interaction/nexus/write_nexus.py
@@ -14,8 +14,7 @@ from hyperion.external_interaction.nexus.nexus_utils import (
     create_beam_and_attenuator_parameters,
     create_detector_parameters,
     create_goniometer_axes,
-    get_current_time,
-    get_predicted_end_time,
+    get_start_and_predicted_end_time,
 )
 from hyperion.parameters.internal_parameters import InternalParameters
 
@@ -76,9 +75,8 @@ class NexusWriter:
         Creates a nexus file based on the parameters supplied when this obect was
         initialised.
         """
-        start_time = get_current_time()
-        est_end_time = get_predicted_end_time(
-            start_time, self.detector.exp_time * self.full_num_of_images
+        start_time, est_end_time = get_start_and_predicted_end_time(
+            self.detector.exp_time * self.full_num_of_images
         )
 
         vds_shape = self.data_shape

--- a/src/hyperion/external_interaction/system_tests/test_write_rotation_nexus.py
+++ b/src/hyperion/external_interaction/system_tests/test_write_rotation_nexus.py
@@ -86,6 +86,9 @@ def test_rotation_scan_nexus_output_compared_to_existing_file(
     with patch(
         "hyperion.external_interaction.nexus.write_nexus.get_current_time",
         return_value="test_time",
+    ), patch(
+        "hyperion.external_interaction.nexus.write_nexus.get_predicted_end_time",
+        return_value="test_time",
     ):
         RE(fake_rotation_scan(test_params, cb))
 
@@ -97,7 +100,7 @@ def test_rotation_scan_nexus_output_compared_to_existing_file(
         h5py.File(nexus_filename, "r") as hyperion_nexus,
     ):
         assert hyperion_nexus["/entry/start_time"][()] == b"test_timeZ"
-        assert hyperion_nexus["/entry/end_time"][()] == b"test_time"
+        assert hyperion_nexus["/entry/end_time_estimated"][()] == b"test_timeZ"
 
         # we used to write the positions wrong...
         hyperion_omega: np.ndarray = np.array(

--- a/src/hyperion/external_interaction/system_tests/test_write_rotation_nexus.py
+++ b/src/hyperion/external_interaction/system_tests/test_write_rotation_nexus.py
@@ -84,11 +84,8 @@ def test_rotation_scan_nexus_output_compared_to_existing_file(
     cb.ispyb_handler.stop = MagicMock()
     cb.ispyb_handler.event = MagicMock()
     with patch(
-        "hyperion.external_interaction.nexus.write_nexus.get_current_time",
-        return_value="test_time",
-    ), patch(
-        "hyperion.external_interaction.nexus.write_nexus.get_predicted_end_time",
-        return_value="test_time",
+        "hyperion.external_interaction.nexus.write_nexus.get_start_and_predicted_end_time",
+        return_value=("test_time", "test_time"),
     ):
         RE(fake_rotation_scan(test_params, cb))
 


### PR DESCRIPTION
Fixes #887 

Writes `end_time_estimated` field in the nexus file at the same time as `start_time` instead of `end_time`, removing the need to reopen the file at the end of the collection.
This is also more in line with the NXmx standard.

### To test:
1. Check tests relating to the nexus write/handler/callback still make sense and pass 
