### PR TITLE
Pin blueapi version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ package_dir =
 install_requires =
     bluesky
     pyepics
-    blueapi @ git+https://github.com/DiamondLightSource/blueapi@main
+    blueapi==0.3.7
     flask-restful
     zocalo
     ispyb


### PR DESCRIPTION
Pin blueapi to version `0.3.7`, which doesn't depend on a specific dodal branch 

### To test:
1. Try running `dls_dev_env.sh` and check that installation finishes correctly
