### PR TITLE
Fix flaky test_main_system tests

### DIFF
--- a/src/hyperion/__main__.py
+++ b/src/hyperion/__main__.py
@@ -221,6 +221,9 @@ class StopOrStatus(Resource):
         action = kwargs.get("action")
         status_and_message = StatusAndMessage(Status.FAILED, f"{action} not understood")
         if action == Actions.STATUS.value:
+            hyperion.log.LOGGER.debug(
+                f"Runner recieved status request - state of the runner object is: {self.runner.__dict__} - state of the RE is: {self.runner.RE.__dict__}"
+            )
             status_and_message = self.runner.current_status
         return asdict(status_and_message)
 

--- a/src/hyperion/system_tests/test_main_system.py
+++ b/src/hyperion/system_tests/test_main_system.py
@@ -76,7 +76,7 @@ class MockRunEngine:
                     "RE_takes_time=false, or set RE.error from another thread."
                 )
         if self.error:
-            self.abort()
+            raise self.error
 
     def abort(self):
         while self.aborting_takes_time:
@@ -248,23 +248,6 @@ def test_given_started_when_stopped_and_started_again_then_runs(
     check_status_in_response(response, Status.SUCCESS)
     response = test_env.client.get(STATUS_ENDPOINT)
     check_status_in_response(response, Status.BUSY)
-
-
-def test_given_started_when_RE_stops_on_its_own_with_error_then_error_reported(
-    caplog,
-    test_env: ClientAndRunEngine,
-):
-    LOGGER.debug(
-        f"Started flaky test - status of RE is {test_env.mock_run_engine.__dict__}"
-    )
-    test_env.mock_run_engine.aborting_takes_time = True
-    test_env.client.put(START_ENDPOINT, data=TEST_PARAMS)
-    test_env.mock_run_engine.error = Exception("D'Oh")
-    response_json = wait_for_run_engine_status(test_env.client)
-    assert response_json["status"] == Status.FAILED.value
-    assert response_json["message"] == 'Exception("D\'Oh")'
-    assert response_json["exception_type"] == "Exception"
-    assert caplog.records[-1].levelname == "ERROR"
 
 
 def test_when_started_n_returnstatus_interrupted_bc_RE_aborted_thn_error_reptd(

--- a/src/hyperion/system_tests/test_main_system.py
+++ b/src/hyperion/system_tests/test_main_system.py
@@ -62,6 +62,9 @@ class MockRunEngine:
     error: Optional[Exception] = None
     test_name = "test"
 
+    def __init__(self, test_name):
+        self.test_name = test_name
+
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         time = 0.0
         while self.RE_takes_time:
@@ -122,8 +125,7 @@ TEST_EXPTS = {
 
 @pytest.fixture
 def test_env(request):
-    mock_run_engine = MockRunEngine()
-    mock_run_engine.test_name = repr(request)
+    mock_run_engine = MockRunEngine(test_name=repr(request))
     mock_context = BlueskyContext()
     real_plans_and_test_exps = dict(
         {k: mock_dict_values(v) for k, v in PLAN_REGISTRY.items()}, **TEST_EXPTS


### PR DESCRIPTION
Fixes #939 

On discussion with @DominicOram we decided just to remove the offending test as diagnosing the issue will take too much time, and we won't be using the blueskyrunner for much longer, and we know it works well on the beamline.

### To test:
1. Run `pytest --random-order -m "not s03" a few times
2. Confirm tests in `test_main_system` don't fail
