### PR TITLE
fix tests for mjpg file handling change in dodal

### DIFF
--- a/src/hyperion/experiment_plans/tests/test_grid_detection_plan.py
+++ b/src/hyperion/experiment_plans/tests/test_grid_detection_plan.py
@@ -46,7 +46,7 @@ def fake_devices(smargon: Smargon, backlight: Backlight):
         "dodal.devices.areadetector.plugins.MJPG.Image"
     ) as mock_image_class:
         mock_image = MagicMock()
-        mock_image_class.open.return_value = mock_image
+        mock_image_class.open.return_value.__enter__.return_value = mock_image
 
         composite = OavGridDetectionComposite(
             backlight=backlight,


### PR DESCRIPTION
Fixes #989 

Recent change in dodal makes the OAV MJPG plugin use a context manager for file opening, this updates our mocks to check `open().__enter__()` instead of `open()`

### To test:
1. Check tests pass
