### PR TITLE
Refactor ISPYB code for robot load: move common parts out and rename

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@7dfbb5ec8b77a257483675c99c591cdef699621c
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@2901ebff3430c6e2772bc795356e3dfd271edef8
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
 

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre.py
@@ -3,14 +3,21 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import bluesky.plan_stubs as bps
 from blueapi.core import BlueskyContext, MsgGenerator
+from dodal.devices.eiger import EigerDetector
+from dodal.devices.smargon import Smargon
 
+from hyperion.device_setup_plans.utils import (
+    start_preparing_data_collection_then_do_plan,
+)
 from hyperion.experiment_plans.grid_detect_then_xray_centre_plan import (
     GridDetectThenXRayCentreComposite,
 )
 from hyperion.experiment_plans.pin_centre_then_xray_centre_plan import (
     pin_tip_centre_then_xray_centre,
 )
+from hyperion.log import LOGGER
 from hyperion.parameters.plan_specific.pin_centre_then_xray_centre_params import (
     PinCentreThenXrayCentreInternalParameters,
 )
@@ -27,15 +34,28 @@ def create_devices(context: BlueskyContext) -> GridDetectThenXRayCentreComposite
     return device_composite_from_context(context, GridDetectThenXRayCentreComposite)
 
 
-def wait_for_robot_load_then_centre(
+def wait_for_smargon_not_disabled(smargon: Smargon, timeout=60):
+    LOGGER.info("Waiting for smargon enabled")
+    SLEEP_PER_CHECK = 0.1
+    times_to_check = int(timeout / SLEEP_PER_CHECK)
+    for _ in range(times_to_check):
+        smargon_disabled = yield from bps.rd(smargon.disabled)
+        if not smargon_disabled:
+            LOGGER.info("Smargon now enabled")
+            return
+        yield from bps.sleep(SLEEP_PER_CHECK)
+    raise TimeoutError(
+        "Timed out waiting for smargon to become enabled after robot load"
+    )
+
+
+def wait_for_robot_load_then_centre_plan(
     composite: GridDetectThenXRayCentreComposite,
     parameters: WaitForRobotLoadThenCentreInternalParameters,
-) -> MsgGenerator:
-    # Start arming the detector
-
+):
     # Move backlight in
 
-    # Wait for robot to finish moving
+    yield from wait_for_smargon_not_disabled(composite.smargon)
 
     # Take snapshot
 
@@ -45,3 +65,19 @@ def wait_for_robot_load_then_centre(
     params_json = json.loads(parameters.json())
     pin_centre_params = PinCentreThenXrayCentreInternalParameters(**params_json)
     yield from pin_tip_centre_then_xray_centre(composite, pin_centre_params)
+
+
+def wait_for_robot_load_then_centre(
+    composite: GridDetectThenXRayCentreComposite,
+    parameters: WaitForRobotLoadThenCentreInternalParameters,
+) -> MsgGenerator:
+    eiger: EigerDetector = composite.eiger
+
+    eiger.set_detector_parameters(parameters.hyperion_params.detector_params)
+
+    return start_preparing_data_collection_then_do_plan(
+        eiger,
+        composite.detector_motion,
+        parameters.experiment_params.detector_distance,
+        wait_for_robot_load_then_centre_plan(composite, parameters),
+    )

--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Dict, Optional
 
 from hyperion.external_interaction.callbacks.plan_reactive_callback import (
     PlanReactiveCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import IspybIds, StoreInIspyb
+from hyperion.external_interaction.ispyb.ispyb_utils import get_ispyb_config
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
+    IspybIds,
+    StoreInIspyb,
+)
 from hyperion.log import ISPYB_LOGGER, set_dcgid_tag
 from hyperion.parameters.constants import (
     ISPYB_HARDWARE_READ_PLAN,
@@ -21,7 +24,9 @@ from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
 )
 
 if TYPE_CHECKING:
-    from hyperion.external_interaction.ispyb.store_in_ispyb import StoreInIspyb
+    from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
+        StoreInIspyb,
+    )
 
 
 class BaseISPyBCallback(PlanReactiveCallback):
@@ -35,7 +40,7 @@ class BaseISPyBCallback(PlanReactiveCallback):
         )
         self.ispyb: StoreInIspyb
         self.descriptors: Dict[str, dict] = {}
-        self.ispyb_config = os.environ.get("ISPYB_CONFIG_PATH", SIM_ISPYB_CONFIG)
+        self.ispyb_config = get_ispyb_config()
         if self.ispyb_config == SIM_ISPYB_CONFIG:
             ISPYB_LOGGER.warning(
                 "Using dev ISPyB database. If you want to use the real database, please"

--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from hyperion.external_interaction.callbacks.ispyb_callback_base import (
     BaseISPyBCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     StoreRotationInIspyb,
 )

--- a/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -4,7 +4,7 @@ from hyperion.external_interaction.callbacks.ispyb_callback_base import (
     BaseISPyBCallback,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     Store2DGridscanInIspyb,
     Store3DGridscanInIspyb,

--- a/src/hyperion/external_interaction/callbacks/xray_centre/zocalo_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/zocalo_callback.py
@@ -13,7 +13,7 @@ from hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.store_in_ispyb import IspybIds
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import IspybIds
 from hyperion.external_interaction.zocalo.zocalo_interaction import (
     NoDiffractionFound,
     ZocaloInteractor,

--- a/src/hyperion/external_interaction/ispyb/ispyb_utils.py
+++ b/src/hyperion/external_interaction/ispyb/ispyb_utils.py
@@ -1,0 +1,35 @@
+import datetime
+import os
+import re
+
+from ispyb import NoResult
+from ispyb.connector.mysqlsp.main import ISPyBMySQLSPConnector as Connector
+from ispyb.sp.core import Core
+
+from hyperion.parameters.constants import (
+    SIM_ISPYB_CONFIG,
+)
+
+VISIT_PATH_REGEX = r".+/([a-zA-Z]{2}\d{4,5}-\d{1,3})(/?$)"
+
+
+def get_current_time_string():
+    now = datetime.datetime.now()
+    return now.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def get_ispyb_config():
+    return os.environ.get("ISPYB_CONFIG_PATH", SIM_ISPYB_CONFIG)
+
+
+def get_visit_string_from_path(path) -> str | None:
+    match = re.search(VISIT_PATH_REGEX, path) if path else None
+    return str(match.group(1)) if match else None
+
+
+def get_session_id_from_visit(conn: Connector, visit: str):
+    try:
+        core: Core = conn.core
+        return core.retrieve_visit_id(visit)
+    except NoResult:
+        raise Exception(f"Not found - session ID for visit {visit}")

--- a/tests/system_tests/external_interaction/conftest.py
+++ b/tests/system_tests/external_interaction/conftest.py
@@ -10,7 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import hyperion.external_interaction.zocalo.zocalo_interaction
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     Store2DGridscanInIspyb,
     Store3DGridscanInIspyb,
 )

--- a/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
@@ -11,7 +11,7 @@ from hyperion.experiment_plans.rotation_scan_plan import (
 from hyperion.external_interaction.callbacks.rotation.callback_collection import (
     RotationCallbackCollection,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     Store2DGridscanInIspyb,
     Store3DGridscanInIspyb,
     StoreGridscanInIspyb,

--- a/tests/unit_tests/experiment_plans/conftest.py
+++ b/tests/unit_tests/experiment_plans/conftest.py
@@ -109,9 +109,10 @@ class RunEngineSimulator:
     2) Calling simulate_plan()
     3) Examining the returned message list and making asserts against them"""
 
-    message_handlers = []
-    callbacks = {}
-    next_callback_token = 0
+    def __init__(self):
+        self.message_handlers = []
+        self.callbacks = {}
+        self.next_callback_token = 0
 
     def add_handler_for_callback_subscribes(self):
         """Add a handler that registers all the callbacks from subscribe messages so we can call them later.

--- a/tests/unit_tests/experiment_plans/conftest.py
+++ b/tests/unit_tests/experiment_plans/conftest.py
@@ -12,7 +12,7 @@ from hyperion.external_interaction.callbacks.rotation.callback_collection import
 from hyperion.external_interaction.callbacks.xray_centre.callback_collection import (
     XrayCentreCallbackCollection,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     Store3DGridscanInIspyb,
 )

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -36,7 +36,7 @@ from hyperion.external_interaction.callbacks.xray_centre.callback_collection imp
 from hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     Store3DGridscanInIspyb,
 )

--- a/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
+++ b/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
@@ -2,6 +2,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from bluesky.run_engine import RunEngine
+from dodal.devices.eiger import EigerDetector
+from dodal.devices.smargon import Smargon
+from ophyd.sim import instantiate_fake_device
 
 from hyperion.experiment_plans.wait_for_robot_load_then_centre import (
     wait_for_robot_load_then_centre,
@@ -13,6 +16,8 @@ from hyperion.parameters.plan_specific.pin_centre_then_xray_centre_params import
 from hyperion.parameters.plan_specific.wait_for_robot_load_then_center_params import (
     WaitForRobotLoadThenCentreInternalParameters,
 )
+
+from .conftest import RunEngineSimulator
 
 
 @pytest.fixture
@@ -31,6 +36,8 @@ def test_when_plan_run_then_centring_plan_run_with_expected_parameters(
     wait_for_robot_load_then_centre_params: WaitForRobotLoadThenCentreInternalParameters,
 ):
     mock_composite = MagicMock()
+    mock_composite.smargon = instantiate_fake_device(Smargon, name="smargon")
+
     RE = RunEngine()
     RE(
         wait_for_robot_load_then_centre(
@@ -44,3 +51,94 @@ def test_when_plan_run_then_centring_plan_run_with_expected_parameters(
 
     assert composite_passed == mock_composite
     assert isinstance(params_passed, PinCentreThenXrayCentreInternalParameters)
+
+
+def run_simulating_smargon_wait(
+    wait_for_robot_load_then_centre_params, total_disabled_reads
+):
+    mock_composite = MagicMock()
+    mock_composite.smargon = instantiate_fake_device(Smargon, name="smargon")
+    mock_composite.eiger = instantiate_fake_device(EigerDetector, name="eiger")
+
+    num_of_reads = 0
+
+    def return_not_disabled_after_reads(_):
+        nonlocal num_of_reads
+        num_of_reads += 1
+        return {"values": {"value": int(num_of_reads < total_disabled_reads)}}
+
+    sim = RunEngineSimulator()
+    sim.add_handler(
+        "read",
+        "smargon_disabled",
+        return_not_disabled_after_reads,
+    )
+
+    return sim.simulate_plan(
+        wait_for_robot_load_then_centre(
+            mock_composite, wait_for_robot_load_then_centre_params
+        )
+    )
+
+
+@pytest.mark.parametrize("total_disabled_reads", [5, 3, 14])
+@patch(
+    "hyperion.experiment_plans.wait_for_robot_load_then_centre.pin_tip_centre_then_xray_centre"
+)
+def test_given_smargon_disabled_when_plan_run_then_waits_on_smargon(
+    mock_centring_plan: MagicMock,
+    wait_for_robot_load_then_centre_params: WaitForRobotLoadThenCentreInternalParameters,
+    total_disabled_reads: int,
+):
+    messages = run_simulating_smargon_wait(
+        wait_for_robot_load_then_centre_params, total_disabled_reads
+    )
+
+    mock_centring_plan.assert_called_once()
+
+    sleep_messages = filter(lambda msg: msg.command == "sleep", messages)
+    read_disabled_messages = filter(
+        lambda msg: msg.command == "read" and msg.obj.name == "smargon_disabled",
+        messages,
+    )
+
+    assert len(list(sleep_messages)) == total_disabled_reads - 1
+    assert len(list(read_disabled_messages)) == total_disabled_reads
+
+
+@patch(
+    "hyperion.experiment_plans.wait_for_robot_load_then_centre.pin_tip_centre_then_xray_centre"
+)
+def test_given_smargon_disabled_for_longer_than_timeout_when_plan_run_then_throws_exception(
+    mock_centring_plan: MagicMock,
+    wait_for_robot_load_then_centre_params: WaitForRobotLoadThenCentreInternalParameters,
+):
+    with pytest.raises(TimeoutError):
+        run_simulating_smargon_wait(wait_for_robot_load_then_centre_params, 1000)
+
+
+@patch(
+    "hyperion.experiment_plans.wait_for_robot_load_then_centre.pin_tip_centre_then_xray_centre"
+)
+def test_when_plan_run_then_detector_arm_started_before_wait_on_robot_load(
+    mock_centring_plan: MagicMock,
+    wait_for_robot_load_then_centre_params: WaitForRobotLoadThenCentreInternalParameters,
+):
+    messages = run_simulating_smargon_wait(wait_for_robot_load_then_centre_params, 1)
+
+    arm_detector_messages = filter(
+        lambda msg: msg.command == "set" and msg.obj.name == "eiger_do_arm",
+        messages,
+    )
+    read_disabled_messages = filter(
+        lambda msg: msg.command == "read" and msg.obj.name == "smargon_disabled",
+        messages,
+    )
+
+    arm_detector_messages = list(arm_detector_messages)
+    assert len(arm_detector_messages) == 1
+
+    idx_of_arm_message = messages.index(arm_detector_messages[0])
+    idx_of_first_read_disabled_message = messages.index(list(read_disabled_messages)[0])
+
+    assert idx_of_arm_message < idx_of_first_read_disabled_message

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -20,7 +20,7 @@ from hyperion.external_interaction.callbacks.xray_centre.callback_collection imp
     XrayCentreCallbackCollection,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     StoreInIspyb,
     StoreRotationInIspyb,

--- a/tests/unit_tests/external_interaction/callbacks/xray_centre/conftest.py
+++ b/tests/unit_tests/external_interaction/callbacks/xray_centre/conftest.py
@@ -29,7 +29,7 @@ def nexus_writer():
 @pytest.fixture
 def mock_ispyb_get_time():
     with patch(
-        "hyperion.external_interaction.callbacks.xray_centre.ispyb_callback.Store3DGridscanInIspyb.get_current_time_string"
+        "hyperion.external_interaction.ispyb.ispyb_utils.get_current_time_string"
     ) as p:
         yield p
 

--- a/tests/unit_tests/external_interaction/callbacks/xray_centre/test_ispyb_handler.py
+++ b/tests/unit_tests/external_interaction/callbacks/xray_centre/test_ispyb_handler.py
@@ -7,7 +7,9 @@ from dodal.log import LOGGER as dodal_logger
 from hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import Store3DGridscanInIspyb
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
+    Store3DGridscanInIspyb,
+)
 from hyperion.log import (
     ISPYB_LOGGER,
     dc_group_id_filter,
@@ -41,11 +43,14 @@ def mock_emit():
 def mock_store_in_ispyb(config, params, *args, **kwargs) -> Store3DGridscanInIspyb:
     mock = Store3DGridscanInIspyb("", params)
     mock.store_grid_scan = MagicMock(return_value=[DC_IDS, None, DCG_ID])
-    mock.get_current_time_string = MagicMock(return_value=td.DUMMY_TIME_STRING)
     mock.update_scan_with_end_time_and_status = MagicMock(return_value=None)
     return mock
 
 
+@patch(
+    "hyperion.external_interaction.ispyb.store_datacollection_in_ispyb.get_current_time_string",
+    MagicMock(return_value=td.DUMMY_TIME_STRING),
+)
 @patch(
     "hyperion.external_interaction.callbacks.xray_centre.ispyb_callback.Store3DGridscanInIspyb",
     mock_store_in_ispyb,

--- a/tests/unit_tests/external_interaction/callbacks/xray_centre/test_zocalo_handler.py
+++ b/tests/unit_tests/external_interaction/callbacks/xray_centre/test_zocalo_handler.py
@@ -7,7 +7,7 @@ from hyperion.external_interaction.callbacks.xray_centre.callback_collection imp
     XrayCentreCallbackCollection,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.store_in_ispyb import IspybIds
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import IspybIds
 from hyperion.external_interaction.zocalo.zocalo_interaction import NoDiffractionFound
 from hyperion.parameters.external_parameters import from_file as default_raw_params
 from hyperion.parameters.plan_specific.gridscan_internal_params import (

--- a/tests/unit_tests/external_interaction/test_ispyb_utils.py
+++ b/tests/unit_tests/external_interaction/test_ispyb_utils.py
@@ -1,0 +1,35 @@
+import re
+
+import pytest
+
+from hyperion.external_interaction.ispyb.ispyb_utils import (
+    get_current_time_string,
+    get_visit_string_from_path,
+)
+
+TIME_FORMAT_REGEX = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+
+
+def test_get_current_time_string():
+    current_time = get_current_time_string()
+
+    assert isinstance(current_time, str)
+    assert re.match(TIME_FORMAT_REGEX, current_time) is not None
+
+
+@pytest.mark.parametrize(
+    "visit_path, expected_match",
+    [
+        ("/dls/i03/data/2022/cm6477-45/", "cm6477-45"),
+        ("/dls/i03/data/2022/cm6477-45", "cm6477-45"),
+        ("/dls/i03/data/2022/mx54663-1/", "mx54663-1"),
+        ("/dls/i03/data/2022/mx54663-1", "mx54663-1"),
+        ("/dls/i03/data/2022/mx53-1/", None),
+        ("/dls/i03/data/2022/mx53-1", None),
+        ("/dls/i03/data/2022/mx5563-1565/", None),
+        ("/dls/i03/data/2022/mx5563-1565", None),
+    ],
+)
+def test_find_visit_in_visit_path(visit_path: str, expected_match: str):
+    test_visit_path = get_visit_string_from_path(visit_path)
+    assert test_visit_path == expected_match

--- a/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
+++ b/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
@@ -1,4 +1,3 @@
-import re
 from copy import deepcopy
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
@@ -7,7 +6,7 @@ import pytest
 from ispyb.sp.mxacquisition import MXAcquisition
 from mockito import mock, when
 
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     Store2DGridscanInIspyb,
     Store3DGridscanInIspyb,
@@ -28,7 +27,6 @@ TEST_GRID_INFO_ID = 56
 TEST_POSITION_ID = 78
 TEST_SESSION_ID = 90
 
-TIME_FORMAT_REGEX = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
 
 EMPTY_DATA_COLLECTION_PARAMS = {
     "id": None,
@@ -147,31 +145,6 @@ def dummy_rotation_ispyb(dummy_rotation_params):
 def dummy_ispyb_3d(dummy_params):
     store_in_ispyb_3d = Store3DGridscanInIspyb(SIM_ISPYB_CONFIG, dummy_params)
     return store_in_ispyb_3d
-
-
-def test_get_current_time_string(dummy_ispyb):
-    current_time = dummy_ispyb.get_current_time_string()
-
-    assert isinstance(current_time, str)
-    assert re.match(TIME_FORMAT_REGEX, current_time) is not None
-
-
-@pytest.mark.parametrize(
-    "visit_path, expected_match",
-    [
-        ("/dls/i03/data/2022/cm6477-45/", "cm6477-45"),
-        ("/dls/i03/data/2022/cm6477-45", "cm6477-45"),
-        ("/dls/i03/data/2022/mx54663-1/", "mx54663-1"),
-        ("/dls/i03/data/2022/mx54663-1", "mx54663-1"),
-        ("/dls/i03/data/2022/mx53-1/", None),
-        ("/dls/i03/data/2022/mx53-1", None),
-        ("/dls/i03/data/2022/mx5563-1565/", None),
-        ("/dls/i03/data/2022/mx5563-1565", None),
-    ],
-)
-def test_regex_string(dummy_ispyb, visit_path: str, expected_match: str):
-    test_visit_path = dummy_ispyb.get_visit_string_from_path(visit_path)
-    assert test_visit_path == expected_match
 
 
 @patch("ispyb.open", new_callable=mock_open)


### PR DESCRIPTION
Part of #1017 

Robot load ispyb entries are very different to data collection ones. This code takes the common parts out and puts them in a utils class.

### To test:
1. Confirm behavior is broadly unchanged
2. Confirm unit tests still pass
