### PR TITLE
Fix issues in robot load found in testing

### DIFF
--- a/src/hyperion/__main__.py
+++ b/src/hyperion/__main__.py
@@ -185,7 +185,7 @@ class RunExperiment(Resource):
                     )
                 if plan is None:
                     raise PlanNotFound(
-                        f"Experiment plan '{plan_name}' has no 'run' method."
+                        f"Experiment plan '{plan_name}' not found in context. Context has {self.context.plan_functions.keys()}"
                     )
 
                 parameters = experiment_internal_param_type.from_json(request.data)

--- a/src/hyperion/experiment_plans/__init__.py
+++ b/src/hyperion/experiment_plans/__init__.py
@@ -10,10 +10,14 @@ from hyperion.experiment_plans.pin_centre_then_xray_centre_plan import (
     pin_tip_centre_then_xray_centre,
 )
 from hyperion.experiment_plans.rotation_scan_plan import rotation_scan
+from hyperion.experiment_plans.wait_for_robot_load_then_centre_plan import (
+    wait_for_robot_load_then_centre,
+)
 
 __all__ = [
     "flyscan_xray_centre",
     "grid_detect_then_xray_centre",
     "rotation_scan",
     "pin_tip_centre_then_xray_centre",
+    "wait_for_robot_load_then_centre",
 ]

--- a/src/hyperion/experiment_plans/experiment_registry.py
+++ b/src/hyperion/experiment_plans/experiment_registry.py
@@ -10,6 +10,7 @@ from hyperion.experiment_plans import (
     grid_detect_then_xray_centre_plan,
     pin_centre_then_xray_centre_plan,
     stepped_grid_scan_plan,
+    wait_for_robot_load_then_centre_plan,
 )
 from hyperion.external_interaction.callbacks.abstract_plan_callback_collection import (
     NullPlanCallbackCollection,
@@ -38,6 +39,10 @@ from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
 from hyperion.parameters.plan_specific.stepped_grid_scan_internal_params import (
     SteppedGridScanInternalParameters,
     SteppedGridScanParams,
+)
+from hyperion.parameters.plan_specific.wait_for_robot_load_then_center_params import (
+    WaitForRobotLoadThenCentreInternalParameters,
+    WaitForRobotLoadThenCentreParams,
 )
 
 
@@ -79,6 +84,12 @@ PLAN_REGISTRY: dict[str, dict[str, Callable]] = {
         "setup": stepped_grid_scan_plan.create_devices,
         "internal_param_type": SteppedGridScanInternalParameters,
         "experiment_param_type": SteppedGridScanParams,
+        "callback_collection_type": NullPlanCallbackCollection,
+    },
+    "wait_for_robot_load_then_centre": {
+        "setup": wait_for_robot_load_then_centre_plan.create_devices,
+        "internal_param_type": WaitForRobotLoadThenCentreInternalParameters,
+        "experiment_param_type": WaitForRobotLoadThenCentreParams,
         "callback_collection_type": NullPlanCallbackCollection,
     },
 }

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
 
 import bluesky.plan_stubs as bps
 from blueapi.core import BlueskyContext, MsgGenerator
@@ -21,11 +20,9 @@ from hyperion.log import LOGGER
 from hyperion.parameters.plan_specific.pin_centre_then_xray_centre_params import (
     PinCentreThenXrayCentreInternalParameters,
 )
-
-if TYPE_CHECKING:
-    from hyperion.parameters.plan_specific.wait_for_robot_load_then_center_params import (
-        WaitForRobotLoadThenCentreInternalParameters,
-    )
+from hyperion.parameters.plan_specific.wait_for_robot_load_then_center_params import (
+    WaitForRobotLoadThenCentreInternalParameters,
+)
 
 
 def create_devices(context: BlueskyContext) -> GridDetectThenXRayCentreComposite:
@@ -66,7 +63,7 @@ def wait_for_robot_load_then_centre_plan(
 
 def wait_for_robot_load_then_centre(
     composite: GridDetectThenXRayCentreComposite,
-    parameters: Any,
+    parameters: WaitForRobotLoadThenCentreInternalParameters,
 ) -> MsgGenerator:
     eiger: EigerDetector = composite.eiger
 

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import bluesky.plan_stubs as bps
 from blueapi.core import BlueskyContext, MsgGenerator
@@ -15,7 +15,7 @@ from hyperion.experiment_plans.grid_detect_then_xray_centre_plan import (
     GridDetectThenXRayCentreComposite,
 )
 from hyperion.experiment_plans.pin_centre_then_xray_centre_plan import (
-    pin_tip_centre_then_xray_centre,
+    pin_centre_then_xray_centre_plan,
 )
 from hyperion.log import LOGGER
 from hyperion.parameters.plan_specific.pin_centre_then_xray_centre_params import (
@@ -61,12 +61,12 @@ def wait_for_robot_load_then_centre_plan(
 
     params_json = json.loads(parameters.json())
     pin_centre_params = PinCentreThenXrayCentreInternalParameters(**params_json)
-    yield from pin_tip_centre_then_xray_centre(composite, pin_centre_params)
+    yield from pin_centre_then_xray_centre_plan(composite, pin_centre_params)
 
 
 def wait_for_robot_load_then_centre(
     composite: GridDetectThenXRayCentreComposite,
-    parameters: WaitForRobotLoadThenCentreInternalParameters,
+    parameters: Any,
 ) -> MsgGenerator:
     eiger: EigerDetector = composite.eiger
 

--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -61,6 +61,7 @@ class BaseISPyBCallback(PlanReactiveCallback):
 
         event_descriptor = self.descriptors[doc["descriptor"]]
         if event_descriptor.get("name") == ISPYB_HARDWARE_READ_PLAN:
+            ISPYB_LOGGER.info("ISPyB handler received event from read hardware")
             self.params.hyperion_params.ispyb_params.undulator_gap = doc["data"][
                 "undulator_current_gap"
             ]

--- a/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -44,7 +44,7 @@ class GridscanISPyBCallback(BaseISPyBCallback):
         if doc.get("subplan_name") == GRIDSCAN_OUTER_PLAN:
             self.uid_to_finalize_on = doc.get("uid")
             ISPYB_LOGGER.info(
-                "ISPyB callback recieved start document with experiment parameters and"
+                "ISPyB callback recieved start document with experiment parameters and "
                 f"uid: {self.uid_to_finalize_on}"
             )
             json_params = doc.get("hyperion_internal_parameters")

--- a/src/hyperion/parameters/plan_specific/wait_for_robot_load_then_center_params.py
+++ b/src/hyperion/parameters/plan_specific/wait_for_robot_load_then_center_params.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
-from dodal.devices.detector import TriggerMode
-from dodal.devices.eiger import DetectorParams
+from dodal.devices.detector import DetectorParams, TriggerMode
+from dodal.parameters.experiment_parameter_base import AbstractExperimentParameterBase
 from pydantic import validator
 from pydantic.dataclasses import dataclass
 
@@ -34,7 +34,7 @@ class WaitForRobotLoadThenCentreHyperionParameters(HyperionParameters):
 
 
 @dataclass
-class WaitForRobotLoadThenCentreParams:
+class WaitForRobotLoadThenCentreParams(AbstractExperimentParameterBase):
     """
     Holder class for the parameters of a plan that waits for robot load then does a
     centre.
@@ -44,6 +44,9 @@ class WaitForRobotLoadThenCentreParams:
     detector_distance: float
     omega_start: float
     snapshot_dir: str
+
+    def get_num_images(self):
+        return 0
 
 
 class WaitForRobotLoadThenCentreInternalParameters(InternalParameters):

--- a/src/hyperion/utils/context.py
+++ b/src/hyperion/utils/context.py
@@ -84,4 +84,6 @@ def setup_context(
         fake_with_ophyd_sim=fake_with_ophyd_sim,
     )
 
+    LOGGER.info(f"Plans found in context: {context.plan_functions.keys()}")
+
     return context

--- a/tests/system_tests/hyperion/test_main_system.py
+++ b/tests/system_tests/hyperion/test_main_system.py
@@ -440,3 +440,4 @@ def test_when_context_created_then_contains_expected_number_of_plans():
         assert "rotation_scan" in plan_names
         assert "flyscan_xray_centre" in plan_names
         assert "pin_tip_centre_then_xray_centre" in plan_names
+        assert "wait_for_robot_load_then_centre" in plan_names

--- a/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
+++ b/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
@@ -4,7 +4,7 @@
         "zocalo_environment": "artemis",
         "beamline": "BL03I",
         "insertion_prefix": "SR03S",
-        "experiment_type": "wait_for_robot_load_then_xray_centre",
+        "experiment_type": "wait_for_robot_load_then_centre",
         "detector_params": {
             "current_energy_ev": 100,
             "directory": "/tmp/",

--- a/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
+++ b/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
@@ -6,7 +6,7 @@ from dodal.devices.eiger import EigerDetector
 from dodal.devices.smargon import Smargon
 from ophyd.sim import instantiate_fake_device
 
-from hyperion.experiment_plans.wait_for_robot_load_then_centre import (
+from hyperion.experiment_plans.wait_for_robot_load_then_centre_plan import (
     wait_for_robot_load_then_centre,
 )
 from hyperion.parameters.external_parameters import from_file as raw_params_from_file
@@ -29,7 +29,7 @@ def wait_for_robot_load_then_centre_params():
 
 
 @patch(
-    "hyperion.experiment_plans.wait_for_robot_load_then_centre.pin_tip_centre_then_xray_centre"
+    "hyperion.experiment_plans.wait_for_robot_load_then_centre_plan.pin_centre_then_xray_centre_plan"
 )
 def test_when_plan_run_then_centring_plan_run_with_expected_parameters(
     mock_centring_plan: MagicMock,
@@ -83,7 +83,7 @@ def run_simulating_smargon_wait(
 
 @pytest.mark.parametrize("total_disabled_reads", [5, 3, 14])
 @patch(
-    "hyperion.experiment_plans.wait_for_robot_load_then_centre.pin_tip_centre_then_xray_centre"
+    "hyperion.experiment_plans.wait_for_robot_load_then_centre_plan.pin_centre_then_xray_centre_plan"
 )
 def test_given_smargon_disabled_when_plan_run_then_waits_on_smargon(
     mock_centring_plan: MagicMock,
@@ -107,7 +107,7 @@ def test_given_smargon_disabled_when_plan_run_then_waits_on_smargon(
 
 
 @patch(
-    "hyperion.experiment_plans.wait_for_robot_load_then_centre.pin_tip_centre_then_xray_centre"
+    "hyperion.experiment_plans.wait_for_robot_load_then_centre_plan.pin_centre_then_xray_centre_plan"
 )
 def test_given_smargon_disabled_for_longer_than_timeout_when_plan_run_then_throws_exception(
     mock_centring_plan: MagicMock,
@@ -118,7 +118,7 @@ def test_given_smargon_disabled_for_longer_than_timeout_when_plan_run_then_throw
 
 
 @patch(
-    "hyperion.experiment_plans.wait_for_robot_load_then_centre.pin_tip_centre_then_xray_centre"
+    "hyperion.experiment_plans.wait_for_robot_load_then_centre_plan.pin_centre_then_xray_centre_plan"
 )
 def test_when_plan_run_then_detector_arm_started_before_wait_on_robot_load(
     mock_centring_plan: MagicMock,


### PR DESCRIPTION
Fixes #1049

### To test:
1. Confirm tests run
1. Start hyperion
```
export BEAMLINE=i03
python -m hyperion --dev --skip-startup-connection
```

In another terminal run an xray centre then robot load plan: `curl -X PUT http://127.0.0.1:5005/wait_for_robot_load_then_centre/start --data-binary "@tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json" -H "Content-Type: application/json"`. Confirm this gives a success
