### PR TITLE
Move common parts out of store in ispyb and rename

### DIFF
--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Dict, Optional
 
 from hyperion.external_interaction.callbacks.plan_reactive_callback import (
     PlanReactiveCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import IspybIds, StoreInIspyb
+from hyperion.external_interaction.ispyb.ispyb_utils import get_ispyb_config
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
+    IspybIds,
+    StoreInIspyb,
+)
 from hyperion.log import ISPYB_LOGGER, set_dcgid_tag
 from hyperion.parameters.constants import (
     ISPYB_HARDWARE_READ_PLAN,
@@ -23,7 +26,9 @@ from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
 if TYPE_CHECKING:
     from event_model.documents.event import Event
 
-    from hyperion.external_interaction.ispyb.store_in_ispyb import StoreInIspyb
+    from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
+        StoreInIspyb,
+    )
 
 
 class BaseISPyBCallback(PlanReactiveCallback):
@@ -37,7 +42,7 @@ class BaseISPyBCallback(PlanReactiveCallback):
         )
         self.ispyb: StoreInIspyb
         self.descriptors: Dict[str, dict] = {}
-        self.ispyb_config = os.environ.get("ISPYB_CONFIG_PATH", SIM_ISPYB_CONFIG)
+        self.ispyb_config = get_ispyb_config()
         if self.ispyb_config == SIM_ISPYB_CONFIG:
             ISPYB_LOGGER.warning(
                 "Using dev ISPyB database. If you want to use the real database, please"

--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from hyperion.external_interaction.callbacks.ispyb_callback_base import (
     BaseISPyBCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     StoreRotationInIspyb,
 )

--- a/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -10,7 +10,7 @@ from hyperion.external_interaction.callbacks.ispyb_callback_base import (
     BaseISPyBCallback,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     Store2DGridscanInIspyb,
     Store3DGridscanInIspyb,

--- a/src/hyperion/external_interaction/callbacks/xray_centre/zocalo_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/zocalo_callback.py
@@ -14,7 +14,7 @@ from hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.store_in_ispyb import IspybIds
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import IspybIds
 from hyperion.log import ISPYB_LOGGER
 from hyperion.parameters.constants import GRIDSCAN_OUTER_PLAN
 from hyperion.parameters.plan_specific.gridscan_internal_params import (

--- a/src/hyperion/external_interaction/ispyb/ispyb_utils.py
+++ b/src/hyperion/external_interaction/ispyb/ispyb_utils.py
@@ -1,0 +1,35 @@
+import datetime
+import os
+import re
+
+from ispyb import NoResult
+from ispyb.connector.mysqlsp.main import ISPyBMySQLSPConnector as Connector
+from ispyb.sp.core import Core
+
+from hyperion.parameters.constants import (
+    SIM_ISPYB_CONFIG,
+)
+
+VISIT_PATH_REGEX = r".+/([a-zA-Z]{2}\d{4,5}-\d{1,3})(/?$)"
+
+
+def get_current_time_string():
+    now = datetime.datetime.now()
+    return now.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def get_ispyb_config():
+    return os.environ.get("ISPYB_CONFIG_PATH", SIM_ISPYB_CONFIG)
+
+
+def get_visit_string_from_path(path) -> str | None:
+    match = re.search(VISIT_PATH_REGEX, path) if path else None
+    return str(match.group(1)) if match else None
+
+
+def get_session_id_from_visit(conn: Connector, visit: str):
+    try:
+        core: Core = conn.core
+        return core.retrieve_visit_id(visit)
+    except NoResult:
+        raise Exception(f"Not found - session ID for visit {visit}")

--- a/src/hyperion/external_interaction/ispyb/ispyb_utils.py
+++ b/src/hyperion/external_interaction/ispyb/ispyb_utils.py
@@ -32,4 +32,4 @@ def get_session_id_from_visit(conn: Connector, visit: str):
         core: Core = conn.core
         return core.retrieve_visit_id(visit)
     except NoResult:
-        raise Exception(f"Not found - session ID for visit {visit}")
+        raise NoResult(f"No session ID found in ispyb for visit {visit}")

--- a/src/hyperion/external_interaction/ispyb/store_datacollection_in_ispyb.py
+++ b/src/hyperion/external_interaction/ispyb/store_datacollection_in_ispyb.py
@@ -52,7 +52,6 @@ class StoreInIspyb(ABC):
         self.detector_params: DetectorParams
         self.run_number: int
         self.omega_start: float
-        self.experiment_type: str
         self.xtal_snapshots: list[str]
         self.data_collection_group_id: int
 

--- a/tests/system_tests/external_interaction/conftest.py
+++ b/tests/system_tests/external_interaction/conftest.py
@@ -10,7 +10,7 @@ from ispyb.sqlalchemy import DataCollection
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     Store2DGridscanInIspyb,
     Store3DGridscanInIspyb,
 )

--- a/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
@@ -11,7 +11,7 @@ from hyperion.experiment_plans.rotation_scan_plan import (
 from hyperion.external_interaction.callbacks.rotation.callback_collection import (
     RotationCallbackCollection,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     Store2DGridscanInIspyb,
     Store3DGridscanInIspyb,
     StoreGridscanInIspyb,

--- a/tests/unit_tests/experiment_plans/conftest.py
+++ b/tests/unit_tests/experiment_plans/conftest.py
@@ -19,7 +19,7 @@ from hyperion.external_interaction.callbacks.xray_centre.callback_collection imp
 from hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     Store3DGridscanInIspyb,
 )

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -37,7 +37,7 @@ from hyperion.external_interaction.callbacks.xray_centre.callback_collection imp
 from hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     Store3DGridscanInIspyb,
 )

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -20,7 +20,7 @@ from hyperion.external_interaction.callbacks.xray_centre.callback_collection imp
     XrayCentreCallbackCollection,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     StoreInIspyb,
     StoreRotationInIspyb,

--- a/tests/unit_tests/external_interaction/callbacks/xray_centre/conftest.py
+++ b/tests/unit_tests/external_interaction/callbacks/xray_centre/conftest.py
@@ -29,7 +29,7 @@ def nexus_writer():
 @pytest.fixture
 def mock_ispyb_get_time():
     with patch(
-        "hyperion.external_interaction.callbacks.xray_centre.ispyb_callback.Store3DGridscanInIspyb.get_current_time_string"
+        "hyperion.external_interaction.ispyb.ispyb_utils.get_current_time_string"
     ) as p:
         yield p
 

--- a/tests/unit_tests/external_interaction/callbacks/xray_centre/test_ispyb_handler.py
+++ b/tests/unit_tests/external_interaction/callbacks/xray_centre/test_ispyb_handler.py
@@ -7,7 +7,9 @@ from dodal.log import LOGGER as dodal_logger
 from hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
     GridscanISPyBCallback,
 )
-from hyperion.external_interaction.ispyb.store_in_ispyb import Store3DGridscanInIspyb
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
+    Store3DGridscanInIspyb,
+)
 from hyperion.log import (
     ISPYB_LOGGER,
     dc_group_id_filter,
@@ -41,11 +43,14 @@ def mock_emit():
 def mock_store_in_ispyb(config, params, *args, **kwargs) -> Store3DGridscanInIspyb:
     mock = Store3DGridscanInIspyb("", params)
     mock.store_grid_scan = MagicMock(return_value=[DC_IDS, None, DCG_ID])
-    mock.get_current_time_string = MagicMock(return_value=td.DUMMY_TIME_STRING)
     mock.update_scan_with_end_time_and_status = MagicMock(return_value=None)
     return mock
 
 
+@patch(
+    "hyperion.external_interaction.ispyb.store_datacollection_in_ispyb.get_current_time_string",
+    MagicMock(return_value=td.DUMMY_TIME_STRING),
+)
 @patch(
     "hyperion.external_interaction.callbacks.xray_centre.ispyb_callback.Store3DGridscanInIspyb",
     mock_store_in_ispyb,

--- a/tests/unit_tests/external_interaction/callbacks/xray_centre/test_zocalo_handler.py
+++ b/tests/unit_tests/external_interaction/callbacks/xray_centre/test_zocalo_handler.py
@@ -6,7 +6,7 @@ from hyperion.external_interaction.callbacks.xray_centre.callback_collection imp
     XrayCentreCallbackCollection,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.store_in_ispyb import IspybIds
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import IspybIds
 from hyperion.parameters.external_parameters import from_file as default_raw_params
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,

--- a/tests/unit_tests/external_interaction/test_ispyb_utils.py
+++ b/tests/unit_tests/external_interaction/test_ispyb_utils.py
@@ -1,0 +1,35 @@
+import re
+
+import pytest
+
+from hyperion.external_interaction.ispyb.ispyb_utils import (
+    get_current_time_string,
+    get_visit_string_from_path,
+)
+
+TIME_FORMAT_REGEX = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+
+
+def test_get_current_time_string():
+    current_time = get_current_time_string()
+
+    assert isinstance(current_time, str)
+    assert re.match(TIME_FORMAT_REGEX, current_time) is not None
+
+
+@pytest.mark.parametrize(
+    "visit_path, expected_match",
+    [
+        ("/dls/i03/data/2022/cm6477-45/", "cm6477-45"),
+        ("/dls/i03/data/2022/cm6477-45", "cm6477-45"),
+        ("/dls/i03/data/2022/mx54663-1/", "mx54663-1"),
+        ("/dls/i03/data/2022/mx54663-1", "mx54663-1"),
+        ("/dls/i03/data/2022/mx53-1/", None),
+        ("/dls/i03/data/2022/mx53-1", None),
+        ("/dls/i03/data/2022/mx5563-1565/", None),
+        ("/dls/i03/data/2022/mx5563-1565", None),
+    ],
+)
+def test_find_visit_in_visit_path(visit_path: str, expected_match: str):
+    test_visit_path = get_visit_string_from_path(visit_path)
+    assert test_visit_path == expected_match

--- a/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
+++ b/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
@@ -1,4 +1,3 @@
-import re
 from copy import deepcopy
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
@@ -7,7 +6,7 @@ import pytest
 from ispyb.sp.mxacquisition import MXAcquisition
 from mockito import mock, when
 
-from hyperion.external_interaction.ispyb.store_in_ispyb import (
+from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     IspybIds,
     Store2DGridscanInIspyb,
     Store3DGridscanInIspyb,
@@ -28,7 +27,6 @@ TEST_GRID_INFO_ID = 56
 TEST_POSITION_ID = 78
 TEST_SESSION_ID = 90
 
-TIME_FORMAT_REGEX = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
 
 EMPTY_DATA_COLLECTION_PARAMS = {
     "id": None,
@@ -147,31 +145,6 @@ def dummy_rotation_ispyb(dummy_rotation_params):
 def dummy_ispyb_3d(dummy_params):
     store_in_ispyb_3d = Store3DGridscanInIspyb(SIM_ISPYB_CONFIG, dummy_params)
     return store_in_ispyb_3d
-
-
-def test_get_current_time_string(dummy_ispyb):
-    current_time = dummy_ispyb.get_current_time_string()
-
-    assert isinstance(current_time, str)
-    assert re.match(TIME_FORMAT_REGEX, current_time) is not None
-
-
-@pytest.mark.parametrize(
-    "visit_path, expected_match",
-    [
-        ("/dls/i03/data/2022/cm6477-45/", "cm6477-45"),
-        ("/dls/i03/data/2022/cm6477-45", "cm6477-45"),
-        ("/dls/i03/data/2022/mx54663-1/", "mx54663-1"),
-        ("/dls/i03/data/2022/mx54663-1", "mx54663-1"),
-        ("/dls/i03/data/2022/mx53-1/", None),
-        ("/dls/i03/data/2022/mx53-1", None),
-        ("/dls/i03/data/2022/mx5563-1565/", None),
-        ("/dls/i03/data/2022/mx5563-1565", None),
-    ],
-)
-def test_regex_string(dummy_ispyb, visit_path: str, expected_match: str):
-    test_visit_path = dummy_ispyb.get_visit_string_from_path(visit_path)
-    assert test_visit_path == expected_match
 
 
 @patch("ispyb.open", new_callable=mock_open)


### PR DESCRIPTION
Part of #1017 

Robot load ispyb entries are very different to data collection ones. This code takes the common parts out and puts them in a utils class.

### To test:
1. Confirm behavior is broadly unchanged
2. Confirm unit tests still pass
