### PR TITLE
1071 replace current energy from gda with requested energy and actual energy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@8f2226b53528bc394df6511943375f9bca6428a1
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@0aabdb389f65a30e629cec60a36c3b5298b7647f
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq

--- a/src/hyperion/device_setup_plans/read_hardware_for_setup.py
+++ b/src/hyperion/device_setup_plans/read_hardware_for_setup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import bluesky.plan_stubs as bps
 from dodal.devices.attenuator import Attenuator
+from dodal.devices.DCM import DCM
 from dodal.devices.flux import Flux
 from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.synchrotron import Synchrotron
@@ -30,9 +31,12 @@ def read_hardware_for_ispyb_pre_collection(
     yield from bps.save()
 
 
-def read_hardware_for_ispyb_during_collection(attenuator: Attenuator, flux: Flux):
+def read_hardware_for_ispyb_during_collection(
+    attenuator: Attenuator, flux: Flux, dcm: DCM
+):
     LOGGER.info("Reading status of beamline parameters for ispyb deposition.")
     yield from bps.create(name=ISPYB_TRANSMISSION_FLUX_READ_PLAN)
     yield from bps.read(attenuator.actual_transmission)
     yield from bps.read(flux.flux_reading)
+    yield from bps.rd(dcm.energy_in_kev)
     yield from bps.save()

--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -13,6 +13,7 @@ from bluesky.utils import ProgressBarManager
 from dodal.devices.aperturescatterguard import ApertureScatterguard
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
+from dodal.devices.DCM import DCM
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import FastGridScan
 from dodal.devices.fast_grid_scan import set_fast_grid_scan_params as set_flyscan_params
@@ -77,6 +78,7 @@ class FlyScanXRayCentreComposite:
     aperture_scatterguard: ApertureScatterguard
     attenuator: Attenuator
     backlight: Backlight
+    dcm: DCM
     eiger: EigerDetector
     fast_grid_scan: FastGridScan
     flux: Flux
@@ -184,8 +186,7 @@ def run_gridscan(
             fgs_composite.s4_slit_gaps,
         )
         yield from read_hardware_for_ispyb_during_collection(
-            fgs_composite.attenuator,
-            fgs_composite.flux,
+            fgs_composite.attenuator, fgs_composite.flux, fgs_composite.dcm
         )
 
     fgs_motors = fgs_composite.fast_grid_scan

--- a/src/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
@@ -11,6 +11,7 @@ from bluesky import preprocessors as bpp
 from dodal.devices.aperturescatterguard import ApertureScatterguard
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
+from dodal.devices.DCM import DCM
 from dodal.devices.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import FastGridScan
@@ -80,6 +81,7 @@ class GridDetectThenXRayCentreComposite:
     aperture_scatterguard: ApertureScatterguard
     attenuator: Attenuator
     backlight: Backlight
+    dcm: DCM
     detector_motion: DetectorMotion
     eiger: EigerDetector
     fast_grid_scan: FastGridScan
@@ -216,6 +218,7 @@ def detect_grid_and_do_gridscan(
         zocalo=composite.zocalo,
         panda=composite.panda,
         fast_grid_scan=composite.fast_grid_scan,
+        dcm=composite.dcm,
     )
 
     if parameters.experiment_params.use_panda:

--- a/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
@@ -112,8 +112,7 @@ def run_gridscan(
             fgs_composite.s4_slit_gaps,
         )
         yield from read_hardware_for_ispyb_during_collection(
-            fgs_composite.attenuator,
-            fgs_composite.flux,
+            fgs_composite.attenuator, fgs_composite.flux, fgs_composite.dcm
         )
 
     fgs_motors = fgs_composite.panda_fast_grid_scan

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -8,6 +8,7 @@ import bluesky.preprocessors as bpp
 from blueapi.core import BlueskyContext, MsgGenerator
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
+from dodal.devices.DCM import DCM
 from dodal.devices.detector import DetectorParams
 from dodal.devices.detector_motion import DetectorMotion
 from dodal.devices.eiger import DetectorParams, EigerDetector
@@ -54,6 +55,7 @@ class RotationScanComposite:
 
     attenuator: Attenuator
     backlight: Backlight
+    dcm: DCM
     detector_motion: DetectorMotion
     eiger: EigerDetector
     flux: Flux
@@ -204,8 +206,7 @@ def rotation_scan_plan(
         composite.s4_slit_gaps,
     )
     yield from read_hardware_for_ispyb_during_collection(
-        composite.attenuator,
-        composite.flux,
+        composite.attenuator, composite.flux, composite.dcm
     )
     LOGGER.info(
         f"Based on image_width {image_width_deg} deg, exposure_time {exposure_time_s}"

--- a/src/hyperion/experiment_plans/set_energy_plan.py
+++ b/src/hyperion/experiment_plans/set_energy_plan.py
@@ -5,7 +5,9 @@
     * reenable feedback
 """
 import dataclasses
+from typing import Any, Generator
 
+from bluesky import Msg
 from bluesky import plan_stubs as bps
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.DCM import DCM
@@ -45,6 +47,11 @@ def _set_energy_plan(
         energy_kev,
     )
     yield from bps.wait(group=UNDULATOR_GROUP)
+
+
+def read_energy(composite: SetEnergyComposite) -> Generator[Msg, Any, float]:
+    """Obtain the energy in kev"""
+    return (yield from bps.rd(composite.dcm.energy_in_kev))  # type: ignore
 
 
 def set_energy_plan(

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
@@ -124,6 +124,11 @@ def wait_for_robot_load_then_centre_plan(
             set_energy_composite,
         )
 
+    actual_energy_ev = 1000 * (yield from bps.rd(composite.dcm.energy_in_kev))
+    parameters.hyperion_params.ispyb_params.current_energy_ev = actual_energy_ev
+    if not parameters.experiment_params.requested_energy_kev:
+        parameters.hyperion_params.detector_params.expected_energy_ev = actual_energy_ev
+
     yield from wait_for_smargon_not_disabled(composite.smargon)
 
     params_json = json.loads(parameters.json())

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
@@ -124,11 +124,6 @@ def wait_for_robot_load_then_centre_plan(
             set_energy_composite,
         )
 
-    actual_energy_ev = 1000 * (yield from bps.rd(composite.dcm.energy_in_kev))
-    parameters.hyperion_params.ispyb_params.current_energy_ev = actual_energy_ev
-    if not parameters.experiment_params.requested_energy_kev:
-        parameters.hyperion_params.detector_params.expected_energy_ev = actual_energy_ev
-
     yield from wait_for_smargon_not_disabled(composite.smargon)
 
     params_json = json.loads(parameters.json())
@@ -165,9 +160,14 @@ def wait_for_robot_load_then_centre(
 ) -> MsgGenerator:
     eiger: EigerDetector = composite.eiger
 
+    actual_energy_ev = 1000 * (yield from bps.rd(composite.dcm.energy_in_kev))
+    parameters.hyperion_params.ispyb_params.current_energy_ev = actual_energy_ev
+    if not parameters.experiment_params.requested_energy_kev:
+        parameters.hyperion_params.detector_params.expected_energy_ev = actual_energy_ev
+
     eiger.set_detector_parameters(parameters.hyperion_params.detector_params)
 
-    return start_preparing_data_collection_then_do_plan(
+    yield from start_preparing_data_collection_then_do_plan(
         eiger,
         composite.detector_motion,
         parameters.experiment_params.detector_distance,

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+from typing import cast
 
 import bluesky.plan_stubs as bps
 from blueapi.core import BlueskyContext, MsgGenerator
@@ -38,6 +39,7 @@ from hyperion.experiment_plans.pin_centre_then_xray_centre_plan import (
 )
 from hyperion.experiment_plans.set_energy_plan import (
     SetEnergyComposite,
+    read_energy,
     set_energy_plan,
 )
 from hyperion.log import LOGGER
@@ -109,19 +111,10 @@ def wait_for_robot_load_then_centre_plan(
     composite: WaitForRobotLoadThenCentreComposite,
     parameters: WaitForRobotLoadThenCentreInternalParameters,
 ):
-    set_energy_composite = SetEnergyComposite(
-        vfm=composite.vfm,
-        vfm_mirror_voltages=composite.vfm_mirror_voltages,
-        dcm=composite.dcm,
-        undulator_dcm=composite.undulator_dcm,
-        xbpm_feedback=composite.xbpm_feedback,
-        attenuator=composite.attenuator,
-    )
-
     if parameters.experiment_params.requested_energy_kev:
         yield from set_energy_plan(
             parameters.experiment_params.requested_energy_kev,
-            set_energy_composite,
+            cast(SetEnergyComposite, composite),
         )
 
     yield from wait_for_smargon_not_disabled(composite.smargon)
@@ -129,28 +122,8 @@ def wait_for_robot_load_then_centre_plan(
     params_json = json.loads(parameters.json())
     pin_centre_params = PinCentreThenXrayCentreInternalParameters(**params_json)
 
-    grid_detect_then_xray_centre_composite = GridDetectThenXRayCentreComposite(
-        aperture_scatterguard=composite.aperture_scatterguard,
-        attenuator=composite.attenuator,
-        backlight=composite.backlight,
-        detector_motion=composite.detector_motion,
-        eiger=composite.eiger,
-        fast_grid_scan=composite.fast_grid_scan,
-        flux=composite.flux,
-        oav=composite.oav,
-        pin_tip_detection=composite.pin_tip_detection,
-        smargon=composite.smargon,
-        synchrotron=composite.synchrotron,
-        s4_slit_gaps=composite.s4_slit_gaps,
-        undulator=composite.undulator,
-        xbpm_feedback=composite.xbpm_feedback,
-        zebra=composite.zebra,
-        zocalo=composite.zocalo,
-        panda=composite.panda,
-        panda_fast_grid_scan=composite.panda_fast_grid_scan,
-    )
     yield from pin_centre_then_xray_centre_plan(
-        grid_detect_then_xray_centre_composite, pin_centre_params
+        cast(GridDetectThenXRayCentreComposite, composite), pin_centre_params
     )
 
 
@@ -160,10 +133,17 @@ def wait_for_robot_load_then_centre(
 ) -> MsgGenerator:
     eiger: EigerDetector = composite.eiger
 
-    actual_energy_ev = 1000 * (yield from bps.rd(composite.dcm.energy_in_kev))
+    actual_energy_ev = 1000 * (
+        yield from read_energy(cast(SetEnergyComposite, composite))
+    )
+
     parameters.hyperion_params.ispyb_params.current_energy_ev = actual_energy_ev
     if not parameters.experiment_params.requested_energy_kev:
         parameters.hyperion_params.detector_params.expected_energy_ev = actual_energy_ev
+    else:
+        parameters.hyperion_params.detector_params.expected_energy_ev = (
+            parameters.experiment_params.requested_energy_kev * 1000
+        )
 
     eiger.set_detector_parameters(parameters.hyperion_params.detector_params)
 

--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -101,6 +101,9 @@ class BaseISPyBCallback(PlanReactiveCallback):
             self.params.hyperion_params.ispyb_params.flux = doc["data"][
                 "flux_flux_reading"
             ]
+            self.params.hyperion_params.ispyb_params.current_energy_ev = doc["data"][
+                "dcm_energy_in_kev"
+            ]
 
             ISPYB_LOGGER.info("Creating ispyb entry.")
             self.ispyb_ids = self.ispyb.begin_deposition()

--- a/src/hyperion/external_interaction/ispyb/ispyb_dataclass.py
+++ b/src/hyperion/external_interaction/ispyb/ispyb_dataclass.py
@@ -39,26 +39,9 @@ class IspybParams(BaseModel):
     microns_per_pixel_y: float
     position: np.ndarray
 
-    class Config:
-        arbitrary_types_allowed = True
-        json_encoders = {np.ndarray: lambda a: a.tolist()}
-
-    def dict(self, **kwargs):
-        as_dict = super().dict(**kwargs)
-        as_dict["position"] = as_dict["position"].tolist()
-        return as_dict
-
-    @validator("position", pre=True)
-    def _parse_position(
-        cls, position: list[int | float] | np.ndarray, values: Dict[str, Any]
-    ) -> np.ndarray:
-        assert len(position) == 3
-        if isinstance(position, np.ndarray):
-            return position
-        return np.array(position)
-
     transmission_fraction: float
-    current_energy_ev: float
+    # populated by wait_for_robot_load_then_centre
+    current_energy_ev: Optional[float]
     beam_size_x: float
     beam_size_y: float
     focal_spot_size_x: float
@@ -77,6 +60,24 @@ class IspybParams(BaseModel):
     slit_gap_size_y: Optional[float] = None
     xtal_snapshots_omega_start: Optional[list[str]] = None
     xtal_snapshots_omega_end: Optional[list[str]] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_encoders = {np.ndarray: lambda a: a.tolist()}
+
+    def dict(self, **kwargs):
+        as_dict = super().dict(**kwargs)
+        as_dict["position"] = as_dict["position"].tolist()
+        return as_dict
+
+    @validator("position", pre=True)
+    def _parse_position(
+        cls, position: list[int | float] | np.ndarray, values: Dict[str, Any]
+    ) -> np.ndarray:
+        assert len(position) == 3
+        if isinstance(position, np.ndarray):
+            return position
+        return np.array(position)
 
     @validator("transmission_fraction")
     def _transmission_not_percentage(cls, transmission_fraction: float):

--- a/src/hyperion/external_interaction/ispyb/ispyb_dataclass.py
+++ b/src/hyperion/external_interaction/ispyb/ispyb_dataclass.py
@@ -13,6 +13,8 @@ GRIDSCAN_ISPYB_PARAM_DEFAULTS = {
     "microns_per_pixel_x": 0.0,
     "microns_per_pixel_y": 0.0,
     "current_energy_ev": 12700,
+    # populate later depending on if requested energy is specified
+    "expected_energy_ev": None,
     # gets stored as 2x2D coords - (x, y) and (x, z). Values in pixels
     "upper_left": [0, 0, 0],
     "position": [0, 0, 0],

--- a/src/hyperion/parameters/plan_specific/rotation_scan_internal_params.py
+++ b/src/hyperion/parameters/plan_specific/rotation_scan_internal_params.py
@@ -129,6 +129,7 @@ class RotationInternalParameters(InternalParameters):
             all_params["omega_increment"] = 0
         all_params["num_triggers"] = 1
         all_params["num_images_per_trigger"] = all_params["num_images"]
+        all_params["current_energy_ev"] = all_params["expected_energy_ev"]
         return RotationHyperionParameters(
             **extract_hyperion_params_from_flat_dict(
                 all_params, cls._hyperion_param_key_definitions()

--- a/src/hyperion/parameters/plan_specific/wait_for_robot_load_then_center_params.py
+++ b/src/hyperion/parameters/plan_specific/wait_for_robot_load_then_center_params.py
@@ -101,6 +101,11 @@ class WaitForRobotLoadThenCentreInternalParameters(InternalParameters):
         all_params["num_images_per_trigger"] = 1
         all_params["trigger_mode"] = TriggerMode.FREE_RUN
         all_params["upper_left"] = np.zeros(3, dtype=np.int32)
+        all_params["expected_energy_ev"] = (
+            experiment_params.requested_energy_kev * 1000
+            if experiment_params.requested_energy_kev
+            else None
+        )
         return WaitForRobotLoadThenCentreHyperionParameters(
             **extract_hyperion_params_from_flat_dict(
                 all_params, cls._hyperion_param_key_definitions()

--- a/src/hyperion/parameters/plan_specific/wait_for_robot_load_then_center_params.py
+++ b/src/hyperion/parameters/plan_specific/wait_for_robot_load_then_center_params.py
@@ -101,11 +101,7 @@ class WaitForRobotLoadThenCentreInternalParameters(InternalParameters):
         all_params["num_images_per_trigger"] = 1
         all_params["trigger_mode"] = TriggerMode.FREE_RUN
         all_params["upper_left"] = np.zeros(3, dtype=np.int32)
-        all_params["expected_energy_ev"] = (
-            experiment_params.requested_energy_kev * 1000
-            if experiment_params.requested_energy_kev
-            else None
-        )
+        all_params["expected_energy_ev"] = None
         return WaitForRobotLoadThenCentreHyperionParameters(
             **extract_hyperion_params_from_flat_dict(
                 all_params, cls._hyperion_param_key_definitions()

--- a/src/hyperion/parameters/schemas/detector_parameters_schema.json
+++ b/src/hyperion/parameters/schemas/detector_parameters_schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
+        "expected_energy_ev": {
+            "type": "number"
+        },
         "directory": {
             "type": "string"
         },
@@ -18,5 +21,11 @@
             "type": "string"
         }
     },
-    "minProperties": 5
+    "required": [
+        "directory",
+        "prefix",
+        "run_number",
+        "use_roi_mode",
+        "det_dist_to_beam_converter_path"
+    ]
 }

--- a/src/hyperion/parameters/schemas/detector_parameters_schema.json
+++ b/src/hyperion/parameters/schemas/detector_parameters_schema.json
@@ -3,7 +3,7 @@
     "type": "object",
     "properties": {
         "expected_energy_ev": {
-            "type": "number"
+            "type": ["number", "null"]
         },
         "directory": {
             "type": "string"

--- a/src/hyperion/parameters/schemas/detector_parameters_schema.json
+++ b/src/hyperion/parameters/schemas/detector_parameters_schema.json
@@ -2,9 +2,6 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
-        "current_energy_ev": {
-            "type": "number"
-        },
         "directory": {
             "type": "string"
         },
@@ -21,5 +18,5 @@
             "type": "string"
         }
     },
-    "minProperties": 6
+    "minProperties": 5
 }

--- a/src/hyperion/parameters/schemas/full_external_parameters_schema.json
+++ b/src/hyperion/parameters/schemas/full_external_parameters_schema.json
@@ -3,7 +3,7 @@
     "type": "object",
     "properties": {
         "params_version": {
-            "const": "4.0.2"
+            "const": "4.0.3"
         },
         "hyperion_params": {
             "type": "object",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from dodal.beamlines.beamline_parameters import GDABeamlineParameters
 from dodal.devices.aperturescatterguard import AperturePositions
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
+from dodal.devices.DCM import DCM
 from dodal.devices.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import GridScanCompleteStatus
@@ -145,7 +146,11 @@ def beamline_parameters():
 
 @pytest.fixture
 def test_fgs_params():
-    return GridscanInternalParameters(**raw_params_from_file())
+    return GridscanInternalParameters(
+        **raw_params_from_file(
+            "tests/test_data/parameter_json_files/test_internal_parameter_defaults.json"
+        )
+    )
 
 
 @pytest.fixture
@@ -387,6 +392,7 @@ def fake_create_rotation_devices(
     undulator: Undulator,
     synchrotron: Synchrotron,
     s4_slit_gaps: S4SlitGaps,
+    dcm: DCM,
     done_status,
 ):
     mock_omega_sets = MagicMock(return_value=Status(done=True, success=True))
@@ -401,6 +407,7 @@ def fake_create_rotation_devices(
     return RotationScanComposite(
         attenuator=attenuator,
         backlight=backlight,
+        dcm=dcm,
         detector_motion=detector_motion,
         eiger=eiger,
         flux=flux,
@@ -435,6 +442,7 @@ def fake_fgs_composite(
         aperture_scatterguard=aperture_scatterguard,
         attenuator=attenuator,
         backlight=i03.backlight(fake_with_ophyd_sim=True),
+        dcm=i03.dcm(fake_with_ophyd_sim=True),
         # We don't use the eiger fixture here because .unstage() is used in some tests
         eiger=i03.eiger(fake_with_ophyd_sim=True),
         fast_grid_scan=i03.fast_grid_scan(fake_with_ophyd_sim=True),

--- a/tests/system_tests/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/experiment_plans/test_fgs_plan.py
@@ -137,13 +137,14 @@ def test_read_hardware_for_ispyb_pre_collection(
     slit_gaps = fgs_composite.s4_slit_gaps
     attenuator = fgs_composite.attenuator
     flux = fgs_composite.flux
+    dcm = fgs_composite.dcm
 
     @bpp.run_decorator()
-    def read_run(u, s, g, a, f):
+    def read_run(u, s, g, a, f, dcm):
         yield from read_hardware_for_ispyb_pre_collection(u, s, g)
-        yield from read_hardware_for_ispyb_during_collection(a, f)
+        yield from read_hardware_for_ispyb_during_collection(a, f, dcm)
 
-    RE(read_run(undulator, synchrotron, slit_gaps, attenuator, flux))
+    RE(read_run(undulator, synchrotron, slit_gaps, attenuator, flux, dcm))
 
 
 @pytest.mark.s03

--- a/tests/system_tests/experiment_plans/test_plan_system.py
+++ b/tests/system_tests/experiment_plans/test_plan_system.py
@@ -19,6 +19,7 @@ def test_getting_data_for_ispyb():
     slit_gaps = S4SlitGaps(f"{SIM_BEAMLINE}-AL-SLITS-04:", name="slits")
     attenuator = i03.attenuator(fake_with_ophyd_sim=True)
     flux = i03.flux(fake_with_ophyd_sim=True)
+    dcm = i03.dcm(fake_with_ophyd_sim=True)
 
     undulator.wait_for_connection()
     synchrotron.wait_for_connection()
@@ -31,6 +32,6 @@ def test_getting_data_for_ispyb():
     @bpp.run_decorator()
     def standalone_read_hardware(und, syn, slits, att, flux):
         yield from read_hardware_for_ispyb_pre_collection(und, syn, slits)
-        yield from read_hardware_for_ispyb_during_collection(att, flux)
+        yield from read_hardware_for_ispyb_during_collection(att, flux, dcm)
 
     RE(standalone_read_hardware(undulator, synchrotron, slit_gaps, attenuator, flux))

--- a/tests/system_tests/experiment_plans/test_rotation_plan.py
+++ b/tests/system_tests/experiment_plans/test_rotation_plan.py
@@ -25,6 +25,7 @@ def devices():
     return RotationScanComposite(
         attenuator=i03.attenuator(),
         backlight=i03.backlight(),
+        dcm=i03.dcm(fake_with_ophyd_sim=True),
         detector_motion=i03.detector_motion(fake_with_ophyd_sim=True),
         eiger=i03.eiger(),
         flux=i03.flux(fake_with_ophyd_sim=True),

--- a/tests/system_tests/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/external_interaction/callbacks/test_external_callbacks.py
@@ -233,6 +233,7 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     composite = RotationScanComposite(
         attenuator=attenuator,
         backlight=fake_create_devices["backlight"],
+        dcm=fake_create_devices["dcm"],
         detector_motion=fake_create_devices["detector_motion"],
         eiger=fake_create_devices["eiger"],
         flux=flux,

--- a/tests/system_tests/external_interaction/callbacks/test_external_callbacks.py
+++ b/tests/system_tests/external_interaction/callbacks/test_external_callbacks.py
@@ -226,7 +226,7 @@ def test_remote_callbacks_write_to_dev_ispyb_for_rotation(
     test_rotation_params.hyperion_params.ispyb_params.current_energy_ev = (
         convert_angstrom_to_eV(test_wl)
     )
-    test_rotation_params.hyperion_params.detector_params.current_energy_ev = (
+    test_rotation_params.hyperion_params.detector_params.expected_energy_ev = (
         convert_angstrom_to_eV(test_wl)
     )
 

--- a/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
@@ -167,6 +167,7 @@ def test_ispyb_deposition_in_rotation_plan(
     composite = RotationScanComposite(
         attenuator=attenuator,
         backlight=fake_create_devices["backlight"],
+        dcm=fake_create_devices["dcm"],
         detector_motion=fake_create_devices["detector_motion"],
         eiger=fake_create_devices["eiger"],
         flux=flux,

--- a/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
@@ -155,7 +155,7 @@ def test_ispyb_deposition_in_rotation_plan(
     test_rotation_params.hyperion_params.ispyb_params.current_energy_ev = (
         convert_angstrom_to_eV(test_wl)
     )
-    test_rotation_params.hyperion_params.detector_params.current_energy_ev = (
+    test_rotation_params.hyperion_params.detector_params.expected_energy_ev = (
         convert_angstrom_to_eV(test_wl)
     )
 

--- a/tests/test_data/parameter_json_files/good_test_grid_with_edge_detect_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_grid_with_edge_detect_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_pin_centre_then_xray_centre_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_pin_centre_then_xray_centre_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
@@ -7,7 +7,7 @@
         "zocalo_environment": "dev_artemis",
         "experiment_type": "rotation_scan",
         "detector_params": {
-            "current_energy_ev": 100,
+            "expected_energy_ev": 100,
             "directory": "/tmp",
             "prefix": "file_name",
             "run_number": 0,

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json
@@ -7,7 +7,7 @@
         "zocalo_environment": "dev_artemis",
         "experiment_type": "rotation_scan",
         "detector_params": {
-            "current_energy_ev": 100,
+            "expected_energy_ev": 100,
             "directory": "/tmp",
             "prefix": "file_name",
             "run_number": 0,

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_stepped_grid_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_stepped_grid_scan_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
+++ b/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
@@ -6,7 +6,6 @@
         "insertion_prefix": "SR03S",
         "experiment_type": "wait_for_robot_load_then_centre",
         "detector_params": {
-            "current_energy_ev": 100,
             "directory": "/tmp/",
             "prefix": "file_name",
             "run_number": 0,

--- a/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
+++ b/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "zocalo_environment": "artemis",
         "beamline": "BL03I",

--- a/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params_no_energy.json
+++ b/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params_no_energy.json
@@ -6,7 +6,6 @@
         "insertion_prefix": "SR03S",
         "experiment_type": "wait_for_robot_load_then_centre",
         "detector_params": {
-            "current_energy_ev": 100,
             "directory": "/tmp/",
             "prefix": "file_name",
             "run_number": 0,

--- a/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params_no_energy.json
+++ b/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params_no_energy.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "zocalo_environment": "artemis",
         "beamline": "BL03I",

--- a/tests/test_data/parameter_json_files/live_test_rotation_params.json
+++ b/tests/test_data/parameter_json_files/live_test_rotation_params.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03I",
         "insertion_prefix": "SR03I",

--- a/tests/test_data/parameter_json_files/live_test_rotation_params_move_xyz.json
+++ b/tests/test_data/parameter_json_files/live_test_rotation_params_move_xyz.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03I",
         "insertion_prefix": "SR03I",

--- a/tests/test_data/parameter_json_files/panda_test_parameters.json
+++ b/tests/test_data/parameter_json_files/panda_test_parameters.json
@@ -12,7 +12,7 @@
             "prefix": "panda_test",
             "run_number": 336,
             "use_roi_mode": false,
-            "det_dist_to_beam_converter_path": "/dls_sw/i03/software/daq_configuration/lookup/DetDistToBeamXYConverter.txt"
+            "det_dist_to_beam_converter_path": "tests/test_data/test_lookup_table.txt"
         },
         "ispyb_params": {
             "current_energy_ev": 12700,

--- a/tests/test_data/parameter_json_files/panda_test_parameters.json
+++ b/tests/test_data/parameter_json_files/panda_test_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03I",
         "insertion_prefix": "SR03I",
@@ -7,7 +7,7 @@
         "zocalo_environment": "artemis",
         "experiment_type": "panda_flyscan_xray_centre",
         "detector_params": {
-            "current_energy_ev": 12700,
+            "expected_energy_ev": 12700,
             "directory": "/dls/i03/data/2023/cm33866-5/test_hyperion",
             "prefix": "panda_test",
             "run_number": 336,
@@ -15,6 +15,7 @@
             "det_dist_to_beam_converter_path": "/dls_sw/i03/software/daq_configuration/lookup/DetDistToBeamXYConverter.txt"
         },
         "ispyb_params": {
+            "current_energy_ev": 12700,
             "visit_path": "/dls/i03/data/2023/cm33866-5/",
             "microns_per_pixel_x": 1.0,
             "microns_per_pixel_y": 1.0,

--- a/tests/test_data/parameter_json_files/test_internal_parameter_defaults.json
+++ b/tests/test_data/parameter_json_files/test_internal_parameter_defaults.json
@@ -14,6 +14,7 @@
             "det_dist_to_beam_converter_path": "tests/test_data/test_lookup_table.txt"
         },
         "ispyb_params": {
+            "current_energy_ev": 100,
             "visit_path": "/tmp/cm31105-4",
             "microns_per_pixel_x": 0.0,
             "microns_per_pixel_y": 0.0,

--- a/tests/test_data/parameter_json_files/test_parameter_defaults.json
+++ b/tests/test_data/parameter_json_files/test_parameter_defaults.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "zocalo_environment": "dev_artemis",
         "beamline": "BL03S",

--- a/tests/test_data/parameter_json_files/test_parameters.json
+++ b/tests/test_data/parameter_json_files/test_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.2",
+    "params_version": "4.0.3",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/unit_tests/experiment_plans/conftest.py
+++ b/tests/unit_tests/experiment_plans/conftest.py
@@ -58,6 +58,7 @@ BASIC_PRE_SETUP_DOC = {
 BASIC_POST_SETUP_DOC = {
     "attenuator_actual_transmission": 0,
     "flux_flux_reading": 10,
+    "dcm_energy_in_kev": 11.105,
 }
 
 
@@ -163,12 +164,13 @@ def fake_read(obj, initial_positions, _):
 
 
 @pytest.fixture
-def simple_beamline(detector_motion, oav, smargon, synchrotron, test_config_files):
+def simple_beamline(detector_motion, oav, smargon, synchrotron, test_config_files, dcm):
     magic_mock = MagicMock(autospec=True)
     magic_mock.oav = oav
     magic_mock.smargon = smargon
     magic_mock.detector_motion = detector_motion
     magic_mock.zocalo = make_fake_device(ZocaloResults)()
+    magic_mock.dcm = dcm
     scan = make_fake_device(FastGridScan)("prefix", name="fake_fgs")
     magic_mock.fast_grid_scan = scan
     magic_mock.synchrotron = synchrotron

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -137,14 +137,14 @@ class TestFlyscanXrayCentrePlan:
         )
 
         transmission_test_value = 0.01
-        fake_fgs_composite.attenuator.actual_transmission.sim_put(
+        fake_fgs_composite.attenuator.actual_transmission.sim_put(  # type: ignore
             transmission_test_value
-        )  # type: ignore
+        )
 
         current_energy_ev_test_value = 12.05
-        fake_fgs_composite.dcm.energy_in_kev.user_readback.sim_put(
+        fake_fgs_composite.dcm.energy_in_kev.user_readback.sim_put(  # type: ignore
             current_energy_ev_test_value
-        )  # type: ignore
+        )
 
         xgap_test_value = 0.1234
         ygap_test_value = 0.2345

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -73,9 +73,9 @@ def ispyb_plan(test_fgs_params):
             "hyperion_internal_parameters": test_fgs_params.json(),
         }
     )
-    def standalone_read_hardware_for_ispyb(und, syn, slits, attn, fl):
+    def standalone_read_hardware_for_ispyb(und, syn, slits, attn, fl, dcm):
         yield from read_hardware_for_ispyb_pre_collection(und, syn, slits)
-        yield from read_hardware_for_ispyb_during_collection(attn, fl)
+        yield from read_hardware_for_ispyb_during_collection(attn, fl, dcm)
 
     return standalone_read_hardware_for_ispyb
 
@@ -137,7 +137,14 @@ class TestFlyscanXrayCentrePlan:
         )
 
         transmission_test_value = 0.01
-        fake_fgs_composite.attenuator.actual_transmission.sim_put(transmission_test_value)  # type: ignore
+        fake_fgs_composite.attenuator.actual_transmission.sim_put(
+            transmission_test_value
+        )  # type: ignore
+
+        current_energy_ev_test_value = 12.05
+        fake_fgs_composite.dcm.energy_in_kev.user_readback.sim_put(
+            current_energy_ev_test_value
+        )  # type: ignore
 
         xgap_test_value = 0.1234
         ygap_test_value = 0.2345
@@ -161,6 +168,7 @@ class TestFlyscanXrayCentrePlan:
                 fake_fgs_composite.s4_slit_gaps,
                 fake_fgs_composite.attenuator,
                 fake_fgs_composite.flux,
+                fake_fgs_composite.dcm,
             )
         )
         params = test_ispyb_callback.params
@@ -177,6 +185,10 @@ class TestFlyscanXrayCentrePlan:
             == transmission_test_value
         )
         assert params.hyperion_params.ispyb_params.flux == flux_test_value  # type: ignore
+        assert (
+            params.hyperion_params.ispyb_params.current_energy_ev
+            == current_energy_ev_test_value
+        )
 
     @patch(
         "dodal.devices.aperturescatterguard.ApertureScatterguard._safe_move_within_datacollection_range"

--- a/tests/unit_tests/experiment_plans/test_grid_detect_then_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_grid_detect_then_xray_centre_plan.py
@@ -82,6 +82,7 @@ def grid_detect_devices(aperture_scatterguard, backlight, detector_motion):
         zocalo=MagicMock(),
         panda=MagicMock(),
         panda_fast_grid_scan=MagicMock(),
+        dcm=MagicMock(),
     )
 
 

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -87,9 +87,9 @@ def ispyb_plan(test_panda_fgs_params):
             "hyperion_internal_parameters": test_panda_fgs_params.json(),
         }
     )
-    def standalone_read_hardware_for_ispyb(und, syn, slits, attn, fl):
+    def standalone_read_hardware_for_ispyb(und, syn, slits, attn, fl, dcm):
         yield from read_hardware_for_ispyb_pre_collection(und, syn, slits)
-        yield from read_hardware_for_ispyb_during_collection(attn, fl)
+        yield from read_hardware_for_ispyb_during_collection(attn, fl, dcm)
 
     return standalone_read_hardware_for_ispyb
 
@@ -168,6 +168,7 @@ class TestFlyscanXrayCentrePlan:
                 fake_fgs_composite.s4_slit_gaps,
                 fake_fgs_composite.attenuator,
                 fake_fgs_composite.flux,
+                fake_fgs_composite.dcm,
             )
         )
         params = test_ispyb_callback.params

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -662,10 +662,15 @@ class TestFlyscanXrayCentrePlan:
         autospec=True,
         spec_set=True,
     )
+    @patch(
+        "hyperion.experiment_plans.panda_flyscan_xray_centre_plan.setup_panda_for_flyscan",
+        autospec=True,
+    )
     def test_when_grid_scan_ran_then_eiger_disarmed_before_zocalo_end(
         self,
         nexuswriter,
         wait_for_valid,
+        mock_setup_panda_for_flyscan,
         mock_mv,
         mock_complete,
         mock_kickoff,

--- a/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
@@ -7,6 +7,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
+from dodal.devices.DCM import DCM
 from dodal.devices.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.flux import Flux
@@ -59,10 +60,12 @@ def do_rotation_main_plan_for_tests(
     sim_zeb,
     sim_bl,
     sim_det,
+    sim_dcm,
 ):
     devices = RotationScanComposite(
         attenuator=sim_att,
         backlight=sim_bl,
+        dcm=sim_dcm,
         detector_motion=sim_det,
         eiger=MagicMock(),
         flux=sim_flux,
@@ -135,6 +138,7 @@ def setup_and_run_rotation_plan_for_tests(
     s4_slit_gaps: S4SlitGaps,
     undulator: Undulator,
     flux: Flux,
+    dcm: DCM,
 ):
     from functools import partial
 
@@ -189,6 +193,7 @@ def setup_and_run_rotation_plan_for_tests(
             zebra,
             backlight,
             detector_motion,
+            dcm,
         )
 
     return {
@@ -221,6 +226,7 @@ def setup_and_run_rotation_plan_for_tests_standard(
     s4_slit_gaps: S4SlitGaps,
     undulator: Undulator,
     flux: Flux,
+    dcm: DCM,
 ):
     return setup_and_run_rotation_plan_for_tests(
         RE_with_subs,
@@ -235,6 +241,7 @@ def setup_and_run_rotation_plan_for_tests_standard(
         s4_slit_gaps,
         undulator,
         flux,
+        dcm,
     )
 
 
@@ -252,6 +259,7 @@ def setup_and_run_rotation_plan_for_tests_nomove(
     s4_slit_gaps: S4SlitGaps,
     undulator: Undulator,
     flux: Flux,
+    dcm: DCM,
 ):
     return setup_and_run_rotation_plan_for_tests(
         RE_with_subs,
@@ -266,6 +274,7 @@ def setup_and_run_rotation_plan_for_tests_nomove(
         s4_slit_gaps,
         undulator,
         flux,
+        dcm,
     )
 
 
@@ -313,6 +322,7 @@ def test_rotation_scan(
     detector_motion: DetectorMotion,
     backlight: Backlight,
     attenuator: Attenuator,
+    dcm: DCM,
 ):
     RE, mock_rotation_subscriptions = RE_with_subs
     zebra.pc.arm.armed.set(False)
@@ -330,6 +340,7 @@ def test_rotation_scan(
         composite = RotationScanComposite(
             attenuator=attenuator,
             backlight=backlight,
+            dcm=dcm,
             detector_motion=detector_motion,
             eiger=eiger,
             flux=MagicMock(),
@@ -445,6 +456,7 @@ def test_cleanup_happens(
     detector_motion: DetectorMotion,
     backlight: Backlight,
     attenuator: Attenuator,
+    dcm: DCM,
 ):
     RE, mock_rotation_subscriptions = RE_with_subs
 
@@ -458,6 +470,7 @@ def test_cleanup_happens(
     composite = RotationScanComposite(
         attenuator=attenuator,
         backlight=backlight,
+        dcm=dcm,
         detector_motion=detector_motion,
         eiger=eiger,
         flux=MagicMock(),
@@ -506,6 +519,7 @@ def test_acceleration_offset_calculated_correctly(
     s4_slit_gaps: S4SlitGaps,
     undulator: Undulator,
     flux: Flux,
+    dcm: DCM,
 ):
     smargon.omega.acceleration.sim_put(0.2)  # type: ignore
     setup_and_run_rotation_plan_for_tests(
@@ -521,6 +535,7 @@ def test_acceleration_offset_calculated_correctly(
         s4_slit_gaps,
         undulator,
         flux,
+        dcm,
     )
 
     expected_start_angle = (

--- a/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
@@ -367,6 +367,20 @@ def test_rotation_plan_zebra_settings(
     assert zebra.pc.pulse_start.get() == expt_params.shutter_opening_time_s
 
 
+def test_rotation_plan_energy_settings(setup_and_run_rotation_plan_for_tests_standard):
+    params: RotationInternalParameters = setup_and_run_rotation_plan_for_tests_standard[
+        "test_rotation_params"
+    ]
+
+    assert (
+        params.hyperion_params.detector_params.expected_energy_ev == 100
+    )  # from good_test_rotation_scan_parameters.json
+    assert (
+        params.hyperion_params.detector_params.expected_energy_ev
+        == params.hyperion_params.ispyb_params.current_energy_ev
+    )
+
+
 def test_full_rotation_plan_smargon_settings(
     run_full_rotation_plan,
     test_rotation_params,

--- a/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
+++ b/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
@@ -63,10 +63,6 @@ def test_when_plan_run_then_centring_plan_run_with_expected_parameters(
 ):
     RE = RunEngine()
 
-    # async def do_nothing_and_return_current_energy(_):
-    #     return 11.105
-
-    # RE.register_command("set_energy_plan", do_nothing_and_return_current_energy)
     RE(
         wait_for_robot_load_then_centre(
             wait_for_robot_load_composite, wait_for_robot_load_then_centre_params

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -6,7 +6,9 @@ import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 import pytest
 from bluesky.run_engine import RunEngine
+from dodal.beamlines.i03 import DAQ_CONFIGURATION_PATH
 from dodal.devices.attenuator import Attenuator
+from dodal.devices.DCM import DCM
 from dodal.devices.flux import Flux
 from ophyd.sim import make_fake_device
 
@@ -66,6 +68,9 @@ def fake_rotation_scan(
 ):
     attenuator = make_fake_device(Attenuator)(name="attenuator")
     flux = make_fake_device(Flux)(name="flux")
+    dcm = make_fake_device(DCM)(
+        name="dcm", daq_configuration_path=DAQ_CONFIGURATION_PATH
+    )
 
     @bpp.subs_decorator(list(subscriptions))
     @bpp.set_run_key_decorator("rotation_scan_with_cleanup_and_subs")
@@ -86,7 +91,7 @@ def fake_rotation_scan(
             }
         )
         def fake_main_plan():
-            yield from read_hardware_for_ispyb_during_collection(attenuator, flux)
+            yield from read_hardware_for_ispyb_during_collection(attenuator, flux, dcm)
             if after_main_do:
                 after_main_do(subscriptions)
             yield from bps.sleep(0)

--- a/tests/unit_tests/external_interaction/callbacks/xray_centre/conftest.py
+++ b/tests/unit_tests/external_interaction/callbacks/xray_centre/conftest.py
@@ -138,6 +138,7 @@ class TestData:
         "data": {
             "attenuator_actual_transmission": 1,
             "flux_flux_reading": 10,
+            "dcm_energy_in_kev": 11.105,
         },
         "timestamps": {"det1": 1666604299.8220396, "det2": 1666604299.8235943},
         "seq_num": 1,

--- a/tests/unit_tests/external_interaction/conftest.py
+++ b/tests/unit_tests/external_interaction/conftest.py
@@ -86,7 +86,7 @@ def test_fgs_params(request):
     params.hyperion_params.ispyb_params.current_energy_ev = convert_angstrom_to_eV(1.0)
     params.hyperion_params.ispyb_params.flux = 9.0
     params.hyperion_params.ispyb_params.transmission_fraction = 0.5
-    params.hyperion_params.detector_params.current_energy_ev = convert_angstrom_to_eV(
+    params.hyperion_params.detector_params.expected_energy_ev = convert_angstrom_to_eV(
         1.0
     )
     params.hyperion_params.detector_params.use_roi_mode = True

--- a/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
+++ b/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
@@ -13,7 +13,7 @@ from hyperion.external_interaction.ispyb.store_datacollection_in_ispyb import (
     StoreRotationInIspyb,
 )
 from hyperion.parameters.constants import SIM_ISPYB_CONFIG
-from hyperion.parameters.external_parameters import from_file as default_raw_params
+from hyperion.parameters.external_parameters import from_file
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,
 )
@@ -108,6 +108,12 @@ EMPTY_DATA_COLLECTION_PARAMS = {
     "c2lens": None,
     "c3lens": None,
 }
+
+
+def default_raw_params(
+    json_file="tests/test_data/parameter_json_files/test_internal_parameter_defaults.json",
+):
+    return from_file(json_file)
 
 
 @pytest.fixture

--- a/tests/unit_tests/external_interaction/test_write_rotation_nexus.py
+++ b/tests/unit_tests/external_interaction/test_write_rotation_nexus.py
@@ -33,7 +33,7 @@ def test_params(tmpdir):
         "prefix"
     ] = f"{tmpdir}/{TEST_FILENAME}"
     param_dict["experiment_params"]["rotation_angle"] = 360.0
-    param_dict["hyperion_params"]["detector_params"]["current_energy_ev"] = 12700
+    param_dict["hyperion_params"]["detector_params"]["expected_energy_ev"] = 12700
     param_dict["hyperion_params"]["ispyb_params"]["current_energy_ev"] = 12700
     param_dict["experiment_params"]["rotation_angle"] = 360.0
     params = RotationInternalParameters(**param_dict)

--- a/tests/unit_tests/parameters/plan_specific/test_rotation_internal_parameters.py
+++ b/tests/unit_tests/parameters/plan_specific/test_rotation_internal_parameters.py
@@ -60,6 +60,7 @@ def test_rotation_parameters_load_from_file():
     detector_params = internal_parameters.hyperion_params.detector_params
 
     assert detector_params.detector_size_constants == EIGER2_X_16M_SIZE
+    assert detector_params.expected_energy_ev == 100
 
 
 def test_rotation_parameters_enum_interpretation():

--- a/tests/unit_tests/parameters/test_internal_parameters.py
+++ b/tests/unit_tests/parameters/test_internal_parameters.py
@@ -175,7 +175,7 @@ def test_hyperion_params_eq(raw_params):
     assert hyperion_params_1 != hyperion_params_2
 
     hyperion_params_2 = copy.deepcopy(hyperion_params_1)
-    hyperion_params_2.detector_params.current_energy_ev = 99999
+    hyperion_params_2.detector_params.expected_energy_ev = 99999
     assert hyperion_params_1 != hyperion_params_2
 
     hyperion_params_2 = copy.deepcopy(hyperion_params_1)


### PR DESCRIPTION
Fixes #1071 

Link to dodal PR (if required): DiamondLightSource/dodal#293

### To test:
1. `current_energy_ev` is now ignored if specified when invoking wait for robot load expt. and is removed from the detector params, in favour of `expected_energy_ev`
2. The energy is now determined by the DCM energy readback during robot load (after energy changes if requested energy was specified) and ispyb param `current_energy_ev` is populated from this
3. If `requested_energy_kev` is specified in the experiment params, the detector params `expected_energy_ev` is populated from this, otherwise the readback energy is used.

