### PR TITLE
1073 make external callbacks optional

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,7 +42,7 @@
                 "debug-test"
             ],
             "env": {
-                "PYTEST_ADDOPTS": "--no-cov"
+                "PYTEST_ADDOPTS": "--no-cov --random-order"
             },
         }
     ]

--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -143,13 +143,15 @@ if [[ $START == 1 ]]; then
     h_commands=()
     for i in "${!h_only_args[@]}"
     do
-        if [ "${h_only_args[$i]}" != false ]; then h_commands+="${h_only_arg_strings[$i]} "; fi;
+        if [ "${h_only_args[$i]}" != false ]; then 
+            h_commands+="${h_only_arg_strings[$i]} ";
+        fi;
     done
     cb_commands=()
     for i in "${!h_and_cb_args[@]}"
     do
         if [ "${h_and_cb_args[$i]}" != false ]; then 
-            cb_commands+="${h_and_cb_arg_strings[$i]} ";
+            h_commands+="${h_and_cb_arg_strings[$i]} ";
             cb_commands+="${h_and_cb_arg_strings[$i]} ";
         fi;
     done

--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -164,8 +164,8 @@ if [[ $START == 1 ]]; then
 
     for i in {1..30}
     do
-        curl --head -X GET http://localhost:5005/status >/dev/null
         echo "$(date)"
+        curl --head -X GET http://localhost:5005/status >/dev/null
         ret_value=$?
         if [ $ret_value -ne 0 ]; then
             sleep 1

--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -162,7 +162,7 @@ if [[ $START == 1 ]]; then
         hyperion-callbacks `echo $cb_commands;`>$callback_start_log_path 2>&1 &
     fi
 
-    echo "$(date) Waiting for Hyperion to boot"
+    echo "$(date) Waiting for Hyperion to start"
 
     for i in {1..30}
     do

--- a/src/hyperion/__main__.py
+++ b/src/hyperion/__main__.py
@@ -152,11 +152,7 @@ class BlueskyRunner:
                 if command.experiment is None:
                     raise ValueError("No experiment provided for START")
                 try:
-                    if (
-                        self.use_external_callbacks
-                        and command.callbacks
-                        and (cbs := list(command.callbacks.setup()))
-                    ):
+                    if command.callbacks and (cbs := list(command.callbacks.setup())):
                         self.subscribed_per_plan_callbacks += [
                             self.RE.subscribe(cb) for cb in cbs
                         ]
@@ -203,10 +199,12 @@ class RunExperiment(Resource):
                         f"Experiment plan '{plan_name}' not found in registry."
                     )
 
-                experiment_internal_param_type = experiment_registry_entry[
+                experiment_internal_param_type = experiment_registry_entry.get(
                     "internal_param_type"
-                ]
-                callback_type = experiment_registry_entry["callback_collection_type"]
+                )
+                callback_type = experiment_registry_entry.get(
+                    "callback_collection_type"
+                )
                 plan = self.context.plan_functions.get(plan_name)
                 if experiment_internal_param_type is None:
                     raise PlanNotFound(

--- a/src/hyperion/__main__.py
+++ b/src/hyperion/__main__.py
@@ -62,14 +62,6 @@ class ErrorStatusAndMessage(StatusAndMessage):
 
 
 class BlueskyRunner:
-    command_queue: "Queue[Command]" = Queue()
-    current_status: StatusAndMessage = StatusAndMessage(Status.IDLE)
-    last_run_aborted: bool = False
-    aperture_change_callback = ApertureChangeCallback()
-    RE: RunEngine
-    skip_startup_connection: bool
-    context: BlueskyContext
-
     def __init__(
         self,
         RE: RunEngine,
@@ -77,6 +69,10 @@ class BlueskyRunner:
         skip_startup_connection=False,
         use_external_callbacks: bool = False,
     ) -> None:
+        self.command_queue: "Queue[Command]" = Queue()
+        self.current_status: StatusAndMessage = StatusAndMessage(Status.IDLE)
+        self.last_run_aborted: bool = False
+        self.aperture_change_callback = ApertureChangeCallback()
         self.RE = RE
         self.context = context
         self.subscribed_per_plan_callbacks: list[int] = []

--- a/src/hyperion/__main__.py
+++ b/src/hyperion/__main__.py
@@ -73,16 +73,19 @@ class BlueskyRunner:
         skip_startup_connection=False,
         use_external_callbacks: bool = False,
     ) -> None:
-        self.publisher = Publisher(f"localhost:{CALLBACK_0MQ_PROXY_PORTS[0]}")
         self.RE = RE
-        self.skip_startup_connection = skip_startup_connection
         self.context = context
-        self.use_external_callbacks = use_external_callbacks
         RE.subscribe(self.aperture_change_callback)
-        RE.subscribe(self.publisher)
+
+        self.use_external_callbacks = use_external_callbacks
+        if self.use_external_callbacks:
+            self.publisher = Publisher(f"localhost:{CALLBACK_0MQ_PROXY_PORTS[0]}")
+            RE.subscribe(self.publisher)
+
         if VERBOSE_EVENT_LOGGING:
             RE.subscribe(VerbosePlanExecutionLoggingCallback())
 
+        self.skip_startup_connection = skip_startup_connection
         if not self.skip_startup_connection:
             for plan_name in PLAN_REGISTRY:
                 PLAN_REGISTRY[plan_name]["setup"](context)

--- a/src/hyperion/experiment_plans/experiment_registry.py
+++ b/src/hyperion/experiment_plans/experiment_registry.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Callable, Union
+from typing import Callable, TypedDict, Union
 
 from dodal.devices.fast_grid_scan import GridScanParams
+from dodal.parameters.experiment_parameter_base import AbstractExperimentParameterBase
 
 import hyperion.experiment_plans.flyscan_xray_centre_plan as flyscan_xray_centre_plan
 import hyperion.experiment_plans.rotation_scan_plan as rotation_scan_plan
@@ -13,6 +14,7 @@ from hyperion.experiment_plans import (
     wait_for_robot_load_then_centre_plan,
 )
 from hyperion.external_interaction.callbacks.abstract_plan_callback_collection import (
+    AbstractPlanCallbackCollection,
     NullPlanCallbackCollection,
 )
 from hyperion.external_interaction.callbacks.rotation.callback_collection import (
@@ -54,8 +56,24 @@ def do_nothing():
     pass
 
 
+class ExperimentRegistryEntry(TypedDict):
+    setup: Callable
+    internal_param_type: (
+        type[
+            GridscanInternalParameters
+            | GridScanWithEdgeDetectInternalParameters
+            | RotationInternalParameters
+            | PinCentreThenXrayCentreInternalParameters
+            | SteppedGridScanInternalParameters
+            | WaitForRobotLoadThenCentreInternalParameters
+        ]
+    )
+    experiment_param_type: type[AbstractExperimentParameterBase]
+    callback_collection_type: type[AbstractPlanCallbackCollection]
+
+
 EXPERIMENT_TYPES = Union[GridScanParams, RotationScanParams, SteppedGridScanParams]
-PLAN_REGISTRY: dict[str, dict[str, Callable]] = {
+PLAN_REGISTRY: dict[str, ExperimentRegistryEntry] = {
     "flyscan_xray_centre": {
         "setup": flyscan_xray_centre_plan.create_devices,
         "internal_param_type": GridscanInternalParameters,

--- a/src/hyperion/external_interaction/callbacks/abstract_plan_callback_collection.py
+++ b/src/hyperion/external_interaction/callbacks/abstract_plan_callback_collection.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import fields
+from typing import Any, Generator
+
+from bluesky.callbacks import CallbackBase
 
 
 class AbstractPlanCallbackCollection(ABC):
@@ -13,10 +16,10 @@ class AbstractPlanCallbackCollection(ABC):
 
     @classmethod
     @abstractmethod
-    def setup(cls):
+    def setup(cls) -> AbstractPlanCallbackCollection:
         ...
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[CallbackBase, Any, None]:
         for field in fields(self):  # type: ignore # subclasses must be dataclass
             yield getattr(self, field.name)
 
@@ -24,4 +27,4 @@ class AbstractPlanCallbackCollection(ABC):
 class NullPlanCallbackCollection(AbstractPlanCallbackCollection):
     @classmethod
     def setup(cls):
-        pass
+        return cls()

--- a/src/hyperion/parameters/cli.py
+++ b/src/hyperion/parameters/cli.py
@@ -1,5 +1,22 @@
 import argparse
 
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class CallbackArgs:
+    logging_level: str
+    dev_mode: bool
+
+
+@dataclass
+class HyperionArgs:
+    logging_level: str
+    dev_mode: bool
+    use_external_callbacks: bool
+    verbose_event_logging: bool
+    skip_startup_connection: bool
+
 
 def add_callback_relevant_args(parser: argparse.ArgumentParser) -> None:
     """adds arguments relevant to hyperion-callbacks. Returns the tuple: (log_level: str, dev_mode: bool)"""
@@ -16,14 +33,14 @@ def add_callback_relevant_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def parse_callback_cli_args() -> tuple[str, bool]:
+def parse_callback_cli_args() -> CallbackArgs:
     parser = argparse.ArgumentParser()
     add_callback_relevant_args(parser)
     args = parser.parse_args()
-    return (args.logging_level, args.dev)
+    return CallbackArgs(logging_level=args.logging_level, dev_mode=args.dev)
 
 
-def parse_cli_args() -> tuple[str | None, bool, bool, bool]:
+def parse_cli_args() -> HyperionArgs:
     """Parses all arguments relevant to hyperion. Returns the tuple: (log_level: str, verbose_event_logging: bool, dev_mode: bool, skip_startup_connection: bool )"""
     parser = argparse.ArgumentParser()
     add_callback_relevant_args(parser)
@@ -37,10 +54,16 @@ def parse_cli_args() -> tuple[str | None, bool, bool, bool]:
         action="store_true",
         help="Skip connecting to EPICS PVs on startup",
     )
+    parser.add_argument(
+        "--external_callbacks",
+        action="store_true",
+        help="Run the external hyperion-callbacks service and publish events over ZMQ",
+    )
     args = parser.parse_args()
-    return (
-        args.logging_level,
-        args.verbose_event_logging,
-        args.dev,
-        args.skip_startup_connection,
+    return HyperionArgs(
+        logging_level=args.logging_level,
+        verbose_event_logging=args.verbose_event_logging,
+        dev_mode=args.dev,
+        skip_startup_connection=args.skip_startup_connection,
+        use_external_callbacks=args.external_callbacks,
     )

--- a/src/hyperion/parameters/cli.py
+++ b/src/hyperion/parameters/cli.py
@@ -55,7 +55,7 @@ def parse_cli_args() -> HyperionArgs:
         help="Skip connecting to EPICS PVs on startup",
     )
     parser.add_argument(
-        "--external_callbacks",
+        "--external-callbacks",
         action="store_true",
         help="Run the external hyperion-callbacks service and publish events over ZMQ",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,7 +252,8 @@ def attenuator():
 def xbpm_feedback(done_status):
     xbpm = i03.xbpm_feedback(fake_with_ophyd_sim=True)
     xbpm.trigger = MagicMock(return_value=done_status)  # type: ignore
-    return xbpm
+    yield xbpm
+    beamline_utils.clear_devices()
 
 
 @pytest.fixture
@@ -287,12 +288,6 @@ def vfm_mirror_voltages():
     voltages = i03.vfm_mirror_voltages(fake_with_ophyd_sim=True)
     voltages.voltage_lookup_table_path = "tests/test_data/test_mirror_focus.json"
     yield voltages
-    beamline_utils.clear_devices()
-
-
-@pytest.fixture
-def xbpm_feedback():
-    yield i03.xbpm_feedback(fake_with_ophyd_sim=True)
     beamline_utils.clear_devices()
 
 

--- a/tests/system_tests/hyperion/test_main_system.py
+++ b/tests/system_tests/hyperion/test_main_system.py
@@ -101,6 +101,9 @@ class MockRunEngine:
     def subscribe(self, *args):
         pass
 
+    def unsubscribe(self, *args):
+        pass
+
 
 @dataclass
 class ClientAndRunEngine:
@@ -364,6 +367,7 @@ def test_blueskyrunner_uses_cli_args_correctly_for_callbacks(
         flask_context.request.data = b"{}"  # type: ignore
         argv[1:] = arg_list
         app, runner, port, dev_mode = create_targets()
+        runner.RE = MagicMock()
         runner_thread = threading.Thread(target=runner.wait_on_queue, daemon=True)
         runner_thread.start()
         assert dev_mode == parsed_arg_values[1]

--- a/tests/system_tests/hyperion/test_main_system.py
+++ b/tests/system_tests/hyperion/test_main_system.py
@@ -132,7 +132,7 @@ def test_env(request):
     mock_run_engine = MockRunEngine(test_name=repr(request))
     mock_context = BlueskyContext()
     real_plans_and_test_exps = dict(
-        {k: mock_dict_values(v) for k, v in PLAN_REGISTRY.items()}, **TEST_EXPTS
+        {k: mock_dict_values(v) for k, v in PLAN_REGISTRY.items()}, **TEST_EXPTS  # type: ignore
     )
     mock_context.plan_functions = {
         k: MagicMock() for k in real_plans_and_test_exps.keys()
@@ -298,7 +298,10 @@ def test_start_with_json_file_gives_success(test_env: ClientAndRunEngine):
             ],
             ("INFO", True, True, True, True),
         ),
-        (["--external-callbacks", "--logging-level=WARNING"], ("WARNING", False, False, False, True)),
+        (
+            ["--external-callbacks", "--logging-level=WARNING"],
+            ("WARNING", False, False, False, True),
+        ),
     ],
 )
 def test_cli_args_parse(arg_list, parsed_arg_values):
@@ -374,7 +377,7 @@ def test_when_blueskyrunner_initiated_and_skip_flag_is_set_then_setup_called_upo
     ):
         runner = BlueskyRunner(MagicMock(), MagicMock(), skip_startup_connection=True)
         mock_setup.assert_not_called()
-        runner.start(None, None, "flyscan_xray_centre")
+        runner.start(None, None, "flyscan_xray_centre", None)  # type: ignore
         mock_setup.assert_called_once()
         runner.shutdown()
 

--- a/tests/system_tests/hyperion/test_main_system.py
+++ b/tests/system_tests/hyperion/test_main_system.py
@@ -324,7 +324,7 @@ def test_cli_args_parse(arg_list, parsed_arg_values):
 @patch("hyperion.__main__.Publisher")
 @patch("hyperion.__main__.setup_context")
 @pytest.mark.parametrize(["arg_list", "parsed_arg_values"], test_argument_combinations)
-def test_blueskyrunner_uses_cli_args_correctly(
+def test_blueskyrunner_uses_cli_args_correctly_for_callbacks(
     setup_context: MagicMock,
     zmq_publisher: MagicMock,
     set_up_logging_handlers: MagicMock,

--- a/tests/system_tests/hyperion/test_main_system.py
+++ b/tests/system_tests/hyperion/test_main_system.py
@@ -109,20 +109,20 @@ def mock_dict_values(d: dict):
 TEST_EXPTS = {
     "test_experiment": {
         "setup": MagicMock(),
-        "run": MagicMock(),
         "internal_param_type": MagicMock(),
         "experiment_param_type": MagicMock(),
+        "callback_collection_type": MagicMock(),
     },
     "test_experiment_no_internal_param_type": {
         "setup": MagicMock(),
-        "run": MagicMock(),
         "experiment_param_type": MagicMock(),
+        "callback_collection_type": MagicMock(),
     },
     "fgs_real_params": {
         "setup": MagicMock(),
-        "run": MagicMock(),
         "internal_param_type": GridscanInternalParameters,
         "experiment_param_type": MagicMock(),
+        "callback_collection_type": MagicMock(),
     },
 }
 
@@ -389,26 +389,26 @@ def test_when_blueskyrunner_initiated_and_skip_flag_is_not_set_then_all_plans_se
         {
             "flyscan_xray_centre": {
                 "setup": mock_setup,
-                "run": MagicMock(),
-                "param_type": MagicMock(),
+                "internal_param_type": MagicMock(),
+                "experiment_param_type": MagicMock(),
                 "callback_collection_type": MagicMock(),
             },
             "rotation_scan": {
                 "setup": mock_setup,
-                "run": MagicMock(),
-                "param_type": MagicMock(),
+                "internal_param_type": MagicMock(),
+                "experiment_param_type": MagicMock(),
                 "callback_collection_type": MagicMock(),
             },
             "other_plan": {
                 "setup": mock_setup,
-                "run": MagicMock(),
-                "param_type": MagicMock(),
+                "internal_param_type": MagicMock(),
+                "experiment_param_type": MagicMock(),
                 "callback_collection_type": MagicMock(),
             },
             "yet_another_plan": {
                 "setup": mock_setup,
-                "run": MagicMock(),
-                "param_type": MagicMock(),
+                "internal_param_type": MagicMock(),
+                "experiment_param_type": MagicMock(),
                 "callback_collection_type": MagicMock(),
             },
         },


### PR DESCRIPTION
Fixes #1073

Requires GDA change https://gerrit.diamond.ac.uk/c/gda/gda-mx/+/40900 to take effect, but shouldn't break anything on its own

### To test:
1. Run tests
2. Run `hyperion_restart()` from GDA (with the above change applied) and see that hyperion is started with the external callbacks turned off