### PR TITLE
1077 hyperion to populate ispyb params resolution instead of gda

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@a5228493da48b24a09bb9ff2d1fd1ef8c69d8c71
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@54af3ccf31a1570dc4bdb0d365f8696a3d130d92
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103

--- a/src/hyperion/device_setup_plans/manipulate_sample.py
+++ b/src/hyperion/device_setup_plans/manipulate_sample.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import bluesky.plan_stubs as bps
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
-from dodal.devices.detector_motion import DetectorMotion
+from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.smargon import Smargon
 
 from hyperion.log import LOGGER

--- a/src/hyperion/device_setup_plans/position_detector.py
+++ b/src/hyperion/device_setup_plans/position_detector.py
@@ -1,5 +1,5 @@
 from bluesky import plan_stubs as bps
-from dodal.devices.detector_motion import DetectorMotion, ShutterState
+from dodal.devices.detector.detector_motion import DetectorMotion, ShutterState
 
 from hyperion.log import LOGGER
 

--- a/src/hyperion/device_setup_plans/utils.py
+++ b/src/hyperion/device_setup_plans/utils.py
@@ -3,7 +3,7 @@ from typing import Generator
 from bluesky import plan_stubs as bps
 from bluesky import preprocessors as bpp
 from bluesky.utils import Msg
-from dodal.devices.detector_motion import DetectorMotion, ShutterState
+from dodal.devices.detector.detector_motion import DetectorMotion, ShutterState
 from dodal.devices.eiger import EigerDetector
 
 from hyperion.device_setup_plans.position_detector import (

--- a/src/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
@@ -12,14 +12,13 @@ from dodal.devices.aperturescatterguard import ApertureScatterguard
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.DCM import DCM
-from dodal.devices.detector_motion import DetectorMotion
+from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import FastGridScan
 from dodal.devices.flux import Flux
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_parameters import OAV_CONFIG_JSON, OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
-from dodal.devices.panda_fast_grid_scan import PandAGridScanParams
 from dodal.devices.robot import BartRobot
 from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.smargon import Smargon
@@ -33,7 +32,6 @@ from hyperion.device_setup_plans.utils import (
     start_preparing_data_collection_then_do_plan,
 )
 from hyperion.experiment_plans.flyscan_xray_centre_plan import (
-    FlyScanXRayCentreComposite,
     flyscan_xray_centre,
 )
 from hyperion.experiment_plans.oav_grid_detection_plan import (

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -9,8 +9,7 @@ from blueapi.core import BlueskyContext, MsgGenerator
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.DCM import DCM
-from dodal.devices.detector import DetectorParams
-from dodal.devices.detector_motion import DetectorMotion
+from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.flux import Flux
 from dodal.devices.robot import BartRobot

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -9,6 +9,7 @@ from blueapi.core import BlueskyContext, MsgGenerator
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.DCM import DCM
+from dodal.devices.detector import DetectorParams
 from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.flux import Flux

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
@@ -10,7 +10,7 @@ from dodal.devices.aperturescatterguard import ApertureScatterguard
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.DCM import DCM
-from dodal.devices.det_resolution import resolution
+from dodal.devices.detector.det_resolution import resolution
 from dodal.devices.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import FastGridScan

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
@@ -10,6 +10,7 @@ from dodal.devices.aperturescatterguard import ApertureScatterguard
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.DCM import DCM
+from dodal.devices.det_resolution import resolution
 from dodal.devices.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import FastGridScan
@@ -49,6 +50,7 @@ from hyperion.parameters.plan_specific.pin_centre_then_xray_centre_params import
 from hyperion.parameters.plan_specific.wait_for_robot_load_then_center_params import (
     WaitForRobotLoadThenCentreInternalParameters,
 )
+from hyperion.utils.utils import convert_eV_to_angstrom
 
 
 @dataclasses.dataclass
@@ -144,6 +146,13 @@ def wait_for_robot_load_then_centre(
         parameters.hyperion_params.detector_params.expected_energy_ev = (
             parameters.experiment_params.requested_energy_kev * 1000
         )
+
+    wavelength_angstroms = convert_eV_to_angstrom(actual_energy_ev)
+    parameters.hyperion_params.ispyb_params.resolution = resolution(
+        parameters.hyperion_params.detector_params,
+        wavelength_angstroms,
+        parameters.experiment_params.detector_distance,
+    )
 
     eiger.set_detector_parameters(parameters.hyperion_params.detector_params)
 

--- a/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
+++ b/src/hyperion/experiment_plans/wait_for_robot_load_then_centre_plan.py
@@ -11,7 +11,7 @@ from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.DCM import DCM
 from dodal.devices.detector.det_resolution import resolution
-from dodal.devices.detector_motion import DetectorMotion
+from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import FastGridScan
 from dodal.devices.flux import Flux

--- a/src/hyperion/external_interaction/ispyb/ispyb_dataclass.py
+++ b/src/hyperion/external_interaction/ispyb/ispyb_dataclass.py
@@ -49,7 +49,8 @@ class IspybParams(BaseModel):
     focal_spot_size_x: float
     focal_spot_size_y: float
     comment: str
-    resolution: float
+    # populated by wait_for_robot_load_then_centre
+    resolution: Optional[float]
 
     sample_id: Optional[str] = None
     sample_barcode: Optional[str] = None

--- a/src/hyperion/parameters/schemas/ispyb_parameters_schema.json
+++ b/src/hyperion/parameters/schemas/ispyb_parameters_schema.json
@@ -90,7 +90,6 @@
         "beam_size_y",
         "focal_spot_size_x",
         "focal_spot_size_y",
-        "comment",
-        "resolution"
+        "comment"
     ]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from dodal.devices.aperturescatterguard import AperturePositions
 from dodal.devices.attenuator import Attenuator
 from dodal.devices.backlight import Backlight
 from dodal.devices.DCM import DCM
-from dodal.devices.detector_motion import DetectorMotion
+from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import GridScanCompleteStatus
 from dodal.devices.flux import Flux

--- a/tests/system_tests/experiment_plans/test_rotation_plan.py
+++ b/tests/system_tests/experiment_plans/test_rotation_plan.py
@@ -14,7 +14,7 @@ from hyperion.experiment_plans.rotation_scan_plan import (
 
 if TYPE_CHECKING:
     from dodal.devices.backlight import Backlight  # noqa
-    from dodal.devices.detector_motion import DetectorMotion  # noqa
+    from dodal.devices.detector.detector_motion import DetectorMotion  # noqa
     from dodal.devices.eiger import EigerDetector  # noqa
     from dodal.devices.smargon import Smargon
     from dodal.devices.zebra import Zebra  # noqa

--- a/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
+++ b/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
@@ -28,7 +28,6 @@
             "focal_spot_size_x": 0.0,
             "focal_spot_size_y": 0.0,
             "comment": "Descriptive comment.",
-            "resolution": 1,
             "sample_id": null,
             "sample_barcode": null
         }

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from bluesky import FailedStatus
 from bluesky.run_engine import RunEngine
-from dodal.devices.det_dim_constants import (
+from dodal.devices.detector.det_dim_constants import (
     EIGER2_X_4M_DIMENSION,
     EIGER_TYPE_EIGER2_X_4M,
     EIGER_TYPE_EIGER2_X_16M,

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -6,7 +6,7 @@ import bluesky.preprocessors as bpp
 import numpy as np
 import pytest
 from bluesky.run_engine import RunEngine
-from dodal.devices.det_dim_constants import (
+from dodal.devices.detector.det_dim_constants import (
     EIGER2_X_4M_DIMENSION,
     EIGER_TYPE_EIGER2_X_4M,
     EIGER_TYPE_EIGER2_X_16M,

--- a/tests/unit_tests/experiment_plans/test_pin_centre_then_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_pin_centre_then_xray_centre_plan.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.utils import Msg
-from dodal.devices.detector_motion import ShutterState
+from dodal.devices.detector.detector_motion import ShutterState
 
 from hyperion.experiment_plans.pin_centre_then_xray_centre_plan import (
     create_parameters_for_grid_detection,

--- a/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
+++ b/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
@@ -5,6 +5,7 @@ from bluesky.run_engine import RunEngine
 from bluesky.utils import Msg
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.smargon import Smargon
+from numpy import isclose
 from ophyd.sim import instantiate_fake_device
 
 from hyperion.experiment_plans.wait_for_robot_load_then_centre_plan import (
@@ -79,6 +80,7 @@ def test_when_plan_run_then_centring_plan_run_with_expected_parameters(
     assert isinstance(params_passed, PinCentreThenXrayCentreInternalParameters)
     assert params_passed.hyperion_params.detector_params.expected_energy_ev == 11100
     assert params_passed.hyperion_params.ispyb_params.current_energy_ev == 11105
+    assert isclose(params_passed.hyperion_params.ispyb_params.resolution, 2.11338)
 
 
 @patch(
@@ -166,6 +168,11 @@ def run_simulating_smargon_wait(
         num_of_reads += 1
         return {"values": {"value": int(num_of_reads < total_disabled_reads)}}
 
+    sim_run_engine.add_handler(
+        "read",
+        "dcm_energy_in_kev",
+        lambda msg: {"dcm_energy_in_kev": {"value": 11.105}},
+    )
     sim_run_engine.add_handler(
         "read",
         "smargon_disabled",

--- a/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
+++ b/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
@@ -80,7 +80,9 @@ def test_when_plan_run_then_centring_plan_run_with_expected_parameters(
     assert isinstance(params_passed, PinCentreThenXrayCentreInternalParameters)
     assert params_passed.hyperion_params.detector_params.expected_energy_ev == 11100
     assert params_passed.hyperion_params.ispyb_params.current_energy_ev == 11105
-    assert isclose(params_passed.hyperion_params.ispyb_params.resolution, 2.11338)
+    assert isclose(
+        params_passed.hyperion_params.ispyb_params.resolution, 2.11338  # type: ignore
+    )
 
 
 @patch(

--- a/tests/unit_tests/external_interaction/nexus/test_write_nexus.py
+++ b/tests/unit_tests/external_interaction/nexus/test_write_nexus.py
@@ -246,7 +246,7 @@ def test_nexus_writer_files_are_formatted_as_expected(
 def test_nexus_writer_writes_width_and_height_correctly(
     single_dummy_file: NexusWriter,
 ):
-    from dodal.devices.det_dim_constants import (
+    from dodal.devices.detector.det_dim_constants import (
         PIXELS_X_EIGER2_X_4M,
         PIXELS_Y_EIGER2_X_4M,
     )
@@ -290,21 +290,21 @@ def check_validity_through_zocalo(nexus_writers: tuple[NexusWriter, NexusWriter]
 
 @pytest.mark.dlstbx
 def test_nexus_file_validity_for_zocalo_with_two_linked_datasets(
-    dummy_nexus_writers: tuple[NexusWriter, NexusWriter]
+    dummy_nexus_writers: tuple[NexusWriter, NexusWriter],
 ):
     check_validity_through_zocalo(dummy_nexus_writers)
 
 
 @pytest.mark.dlstbx
 def test_nexus_file_validity_for_zocalo_with_three_linked_datasets(
-    dummy_nexus_writers_with_more_images: tuple[NexusWriter, NexusWriter]
+    dummy_nexus_writers_with_more_images: tuple[NexusWriter, NexusWriter],
 ):
     check_validity_through_zocalo(dummy_nexus_writers_with_more_images)
 
 
 @pytest.mark.skip("Requires #87 of nexgen")
 def test_given_some_datafiles_outside_of_VDS_range_THEN_they_are_not_in_nexus_file(
-    dummy_nexus_writers_with_more_images: tuple[NexusWriter, NexusWriter]
+    dummy_nexus_writers_with_more_images: tuple[NexusWriter, NexusWriter],
 ):
     nexus_writer_1, nexus_writer_2 = dummy_nexus_writers_with_more_images
 

--- a/tests/unit_tests/parameters/plan_specific/test_fgs_internal_parameters.py
+++ b/tests/unit_tests/parameters/plan_specific/test_fgs_internal_parameters.py
@@ -1,5 +1,5 @@
 import numpy as np
-from dodal.devices.det_dim_constants import EIGER2_X_16M_SIZE
+from dodal.devices.detector.det_dim_constants import EIGER2_X_16M_SIZE
 from dodal.devices.fast_grid_scan import GridScanParams
 
 from hyperion.parameters import external_parameters

--- a/tests/unit_tests/parameters/plan_specific/test_grid_scan_with_edge_detect_internal_parameters.py
+++ b/tests/unit_tests/parameters/plan_specific/test_grid_scan_with_edge_detect_internal_parameters.py
@@ -1,5 +1,5 @@
 import numpy as np
-from dodal.devices.det_dim_constants import EIGER2_X_16M_SIZE
+from dodal.devices.detector.det_dim_constants import EIGER2_X_16M_SIZE
 
 from hyperion.parameters import external_parameters
 from hyperion.parameters.plan_specific.grid_scan_with_edge_detect_params import (

--- a/tests/unit_tests/parameters/plan_specific/test_rotation_internal_parameters.py
+++ b/tests/unit_tests/parameters/plan_specific/test_rotation_internal_parameters.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-from dodal.devices.det_dim_constants import EIGER2_X_16M_SIZE
+from dodal.devices.detector.det_dim_constants import EIGER2_X_16M_SIZE
 from dodal.devices.motors import XYZLimitBundle
 
 from hyperion.parameters import external_parameters


### PR DESCRIPTION
Fixes #1077 

Link to dodal PR (if required): DiamondLightSource/dodal#296

Link to GDA Gerrit change: https://gerrit.diamond.ac.uk/c/gda/gda-mx/+/41000

### To test:
1. It should be possible for wait_for_robot_load_then_centre_plan to populate the ispyb resolution without requiring the parameter to be specified in the hyperion request.
