### PR TITLE
Discard old processing results

### DIFF
--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -159,6 +159,7 @@ def run_gridscan(
         "plan_name": GRIDSCAN_MAIN_PLAN,
     },
 ):
+    yield from bps.stage(fgs_composite.zocalo)  # clear any stale processing results
     sample_motors = fgs_composite.sample_motors
 
     # Currently gridscan only works for omega 0, see #

--- a/src/hyperion/external_interaction/ispyb/store_datacollection_in_ispyb.py
+++ b/src/hyperion/external_interaction/ispyb/store_datacollection_in_ispyb.py
@@ -414,8 +414,8 @@ class StoreGridscanInIspyb(StoreInIspyb):
             "Hyperion: Xray centring - Diffraction grid scan of "
             f"{self.full_params.experiment_params.x_steps} by "
             f"{self.y_steps} images in "
-            f"{self.full_params.experiment_params.x_step_size*1e3} um by "
-            f"{self.y_step_size*1e3} um steps. "
+            f"{(self.full_params.experiment_params.x_step_size*1e3):.1f} um by "
+            f"{(self.y_step_size*1e3):.1f} um steps. "
             f"Top left (px): [{int(self.upper_left[0])},{int(self.upper_left[1])}], "
             f"bottom right (px): [{bottom_right[0]},{bottom_right[1]}]."
         )


### PR DESCRIPTION
Fixes #1072 fixes #1080

- Adds ZocaloResults stage call which wipes old results from the queue
- Rounds ISPyB comment box sizes to 1DP

Link to dodal PR (if required): [#297](https://github.com/DiamondLightSource/dodal/pull/297)

### To test:
1. Run tests
