### PR TITLE
(#1046) Fix eiger not disarming if detector setup fails

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@15fc272e365fd6a52af2b7ef1e16ca5bf7ba868e
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@0c0a5e4f475cf88e947be2177e72c1d16d2a392d
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     zmq

--- a/src/hyperion/device_setup_plans/utils.py
+++ b/src/hyperion/device_setup_plans/utils.py
@@ -28,12 +28,14 @@ def start_preparing_data_collection_then_do_plan(
      * Opening the detect shutter
      If the plan fails it will disarm the eiger.
     """
-    yield from bps.abs_set(eiger.do_arm, 1, group=group)
 
-    yield from set_detector_z_position(detector_motion, detector_distance, group)
-    yield from set_shutter(detector_motion, ShutterState.OPEN, group)
+    def wrapped_plan():
+        yield from bps.abs_set(eiger.do_arm, 1, group=group)
+        yield from set_detector_z_position(detector_motion, detector_distance, group)
+        yield from set_shutter(detector_motion, ShutterState.OPEN, group)
+        yield from plan_to_run
 
     yield from bpp.contingency_wrapper(
-        plan_to_run,
+        wrapped_plan(),
         except_plan=lambda e: (yield from bps.stop(eiger)),
     )

--- a/tests/unit_tests/device_setup_plans/test_utils.py
+++ b/tests/unit_tests/device_setup_plans/test_utils.py
@@ -1,27 +1,38 @@
 from unittest.mock import MagicMock
 
 import pytest
+from bluesky import FailedStatus
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i03
+from ophyd.status import Status
 
 from hyperion.device_setup_plans.utils import (
     start_preparing_data_collection_then_do_plan,
 )
 
 
-def test_given_plan_raises_when_exception_raised_then_eiger_disarmed_and_correct_exception_returned():
-    class TestException(Exception):
-        pass
-
-    def my_plan():
-        yield from bps.null()
-        raise TestException()
-
+@pytest.fixture()
+def mock_eiger():
     eiger = i03.eiger(fake_with_ophyd_sim=True)
     eiger.detector_params = MagicMock()
     eiger.async_stage = MagicMock()
     eiger.disarm_detector = MagicMock()
+    return eiger
+
+
+class TestException(Exception):
+    pass
+
+
+def test_given_plan_raises_when_exception_raised_then_eiger_disarmed_and_correct_exception_returned(
+    mock_eiger,
+):
+    def my_plan():
+        yield from bps.null()
+        raise TestException()
+
+    eiger = mock_eiger
     detector_motion = MagicMock()
 
     RE = RunEngine()
@@ -37,3 +48,48 @@ def test_given_plan_raises_when_exception_raised_then_eiger_disarmed_and_correct
     eiger.async_stage.assert_called_once()
 
     eiger.disarm_detector.assert_called_once()
+
+
+@pytest.fixture()
+def null_plan():
+    yield from bps.null()
+
+
+def test_given_shutter_open_fails_then_eiger_disarmed_and_correct_exception_returned(
+    mock_eiger, null_plan
+):
+    detector_motion = MagicMock()
+    RE = RunEngine()
+    detector_motion.z.set = MagicMock(return_value=Status(done=True, success=False))
+
+    with pytest.raises(FailedStatus):
+        RE(
+            start_preparing_data_collection_then_do_plan(
+                mock_eiger, detector_motion, 100, null_plan
+            )
+        )
+
+    mock_eiger.async_stage.assert_called_once()
+    detector_motion.z.set.assert_called_once()
+    mock_eiger.disarm_detector.assert_called_once()
+
+
+def test_given_detector_move_fails_then_eiger_disarmed_and_correct_exception_returned(
+    mock_eiger, null_plan
+):
+    detector_motion = MagicMock()
+    RE = RunEngine()
+    detector_motion.shutter.set = MagicMock(
+        return_value=Status(done=True, success=False)
+    )
+
+    with pytest.raises(FailedStatus):
+        RE(
+            start_preparing_data_collection_then_do_plan(
+                mock_eiger, detector_motion, 100, null_plan
+            )
+        )
+
+    mock_eiger.async_stage.assert_called_once()
+    detector_motion.z.set.assert_called_once()
+    mock_eiger.disarm_detector.assert_called_once()

--- a/tests/unit_tests/device_setup_plans/test_utils.py
+++ b/tests/unit_tests/device_setup_plans/test_utils.py
@@ -52,7 +52,7 @@ def test_given_plan_raises_when_exception_raised_then_eiger_disarmed_and_correct
 
 @pytest.fixture()
 def null_plan():
-    yield from bps.null()
+    return bps.null()
 
 
 def test_given_shutter_open_fails_then_eiger_disarmed_and_correct_exception_returned(
@@ -60,14 +60,16 @@ def test_given_shutter_open_fails_then_eiger_disarmed_and_correct_exception_retu
 ):
     detector_motion = MagicMock()
     RE = RunEngine()
-    detector_motion.z.set = MagicMock(return_value=Status(done=True, success=False))
+    status = Status(done=True, success=False)
+    detector_motion.z.set = MagicMock(return_value=status)
 
-    with pytest.raises(FailedStatus):
+    with pytest.raises(FailedStatus) as e:
         RE(
             start_preparing_data_collection_then_do_plan(
                 mock_eiger, detector_motion, 100, null_plan
             )
         )
+    assert e.value.args[0] is status
 
     mock_eiger.async_stage.assert_called_once()
     detector_motion.z.set.assert_called_once()


### PR DESCRIPTION
Fixes #1046

Link to dodal PR (if required):N/A
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. Eiger should now disarm if detector move fails or if the shutter fails to open. Note that the detector position and shutter state are not restored.
