### PR TITLE
Fix flaky main system test

### DIFF
--- a/src/hyperion/__main__.py
+++ b/src/hyperion/__main__.py
@@ -58,17 +58,15 @@ class ErrorStatusAndMessage(StatusAndMessage):
 
 
 class BlueskyRunner:
-    command_queue: "Queue[Command]" = Queue()
-    current_status: StatusAndMessage = StatusAndMessage(Status.IDLE)
-    last_run_aborted: bool = False
-    aperture_change_callback = ApertureChangeCallback()
-    RE: RunEngine
-    skip_startup_connection: bool
-    context: BlueskyContext
-
     def __init__(
         self, RE: RunEngine, context: BlueskyContext, skip_startup_connection=False
     ) -> None:
+        self.command_queue: Queue[Command] = Queue()
+        self.current_status: StatusAndMessage = StatusAndMessage(Status.IDLE)
+        self.last_run_aborted: bool = False
+        self.aperture_change_callback = ApertureChangeCallback()
+        self.context: BlueskyContext
+
         self.publisher = Publisher(f"localhost:{CALLBACK_0MQ_PROXY_PORTS[0]}")
         self.RE = RE
         self.skip_startup_connection = skip_startup_connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,12 @@ def RE():
     RE.subscribe(
         VerbosePlanExecutionLoggingCallback()
     )  # log all events at INFO for easier debugging
-    return RE
+    yield RE
+    try:
+        RE.halt()
+    except Exception:
+        pass
+    del RE
 
 
 def mock_set(motor: EpicsMotor, val):

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -152,6 +152,7 @@ def test_env(request):
 
     runner.shutdown()
     runner_thread.join(timeout=3)
+    del mock_run_engine
 
 
 def wait_for_run_engine_status(
@@ -249,10 +250,12 @@ def test_given_started_when_stopped_and_started_again_then_runs(
 ):
     test_env.client.put(START_ENDPOINT, data=TEST_PARAMS)
     test_env.client.put(STOP_ENDPOINT)
+    test_env.mock_run_engine.RE_takes_time = True
     response = test_env.client.put(START_ENDPOINT, data=TEST_PARAMS)
     check_status_in_response(response, Status.SUCCESS)
     response = test_env.client.get(STATUS_ENDPOINT)
     check_status_in_response(response, Status.BUSY)
+    test_env.mock_run_engine.RE_takes_time = False
 
 
 def test_when_started_n_returnstatus_interrupted_bc_RE_aborted_thn_error_reptd(

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -61,12 +61,11 @@ autospec_patch = functools.partial(patch, autospec=True, spec_set=True)
 
 
 class MockRunEngine:
-    RE_takes_time = True
-    aborting_takes_time = False
-    error: Optional[Exception] = None
-    test_name = "test"
-
     def __init__(self, test_name):
+        self.RE_takes_time = True
+        self.aborting_takes_time = False
+        self.error: Optional[Exception] = None
+        self.test_name = "test"
         self.test_name = test_name
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:

--- a/tests/unit_tests/hyperion/test_main_system.py
+++ b/tests/unit_tests/hyperion/test_main_system.py
@@ -65,7 +65,6 @@ class MockRunEngine:
         self.RE_takes_time = True
         self.aborting_takes_time = False
         self.error: Optional[Exception] = None
-        self.test_name = "test"
         self.test_name = test_name
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:


### PR DESCRIPTION
- Properly destroys the `RunEngine` after each test
- stops some classes holding state they shouldn't
 

Maybe fixes that flaky test, who knows. I ran the tests a little over 50 times with

```bash
for i in {0..50}; do 
    pytest --random-order -m "not s03";
    if [ $? -ne 0 ]; then 
        break; 
    fi; 
done
```

and didn't get any failures.