### PR TITLE
920 Combine rotations in ispyb

### DIFF
--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -114,7 +114,6 @@ class BaseISPyBCallback(PlanReactiveCallback):
             doc.get("exit_status") or "Exit status not available in stop document!"
         )
         reason = doc.get("reason") or ""
-
         set_dcgid_tag(None)
         try:
             self.ispyb.end_deposition(exit_status, reason)

--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -26,6 +26,9 @@ from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
 
 if TYPE_CHECKING:
     from event_model.documents.event import Event
+    from event_model.documents.event_descriptor import EventDescriptor
+    from event_model.documents.run_start import RunStart
+    from event_model.documents.run_stop import RunStop
 
 
 class BaseISPyBCallback(PlanReactiveCallback):
@@ -39,7 +42,7 @@ class BaseISPyBCallback(PlanReactiveCallback):
             None
         )
         self.ispyb: StoreInIspyb
-        self.descriptors: Dict[str, dict] = {}
+        self.descriptors: Dict[str, EventDescriptor] = {}
         self.ispyb_config = get_ispyb_config()
         if (
             self.ispyb_config == SIM_ISPYB_CONFIG
@@ -54,12 +57,12 @@ class BaseISPyBCallback(PlanReactiveCallback):
         self.ispyb_ids: IspybIds = IspybIds()
         self.log = ISPYB_LOGGER
 
-    def activity_gated_start(self, doc: dict):
+    def activity_gated_start(self, doc: RunStart):
         ISPYB_LOGGER.debug("ISPyB Callback Start Triggered")
         if self.uid_to_finalize_on is None:
             self.uid_to_finalize_on = doc.get("uid")
 
-    def activity_gated_descriptor(self, doc: dict):
+    def activity_gated_descriptor(self, doc: EventDescriptor):
         self.descriptors[doc["uid"]] = doc
 
     def activity_gated_event(self, doc: Event):
@@ -103,7 +106,7 @@ class BaseISPyBCallback(PlanReactiveCallback):
             self.ispyb_ids = self.ispyb.begin_deposition()
             ISPYB_LOGGER.info(f"Recieved ISPYB IDs: {self.ispyb_ids}")
 
-    def activity_gated_stop(self, doc: dict):
+    def activity_gated_stop(self, doc: RunStop):
         """Subclasses must check that they are recieving a stop document for the correct
         uid to use this method!"""
         assert isinstance(

--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -17,6 +17,8 @@ from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
 
 if TYPE_CHECKING:
     from event_model.documents.event import Event
+    from event_model.documents.run_start import RunStart
+    from event_model.documents.run_stop import RunStop
 
 
 class RotationISPyBCallback(BaseISPyBCallback):
@@ -44,7 +46,7 @@ class RotationISPyBCallback(BaseISPyBCallback):
         assert isinstance(self.ispyb_ids.data_collection_ids, int)
         self._append_to_comment(self.ispyb_ids.data_collection_ids, comment)
 
-    def activity_gated_start(self, doc: dict):
+    def activity_gated_start(self, doc: RunStart):
         if doc.get("subplan_name") == ROTATION_OUTER_PLAN:
             ISPYB_LOGGER.info(
                 "ISPyB callback recieved start document with experiment parameters."
@@ -70,7 +72,7 @@ class RotationISPyBCallback(BaseISPyBCallback):
         super().activity_gated_event(doc)
         set_dcgid_tag(self.ispyb_ids.data_collection_group_id)
 
-    def activity_gated_stop(self, doc: dict):
+    def activity_gated_stop(self, doc: RunStop):
         if doc.get("run_start") == self.uid_to_finalize_on:
             self.uid_to_finalize_on = None
             super().activity_gated_stop(doc)

--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -59,9 +59,7 @@ class RotationISPyBCallback(BaseISPyBCallback):
                 )
                 else None
             )
-            self.ispyb: StoreRotationInIspyb = StoreRotationInIspyb(
-                self.ispyb_config, self.params, dcgid
-            )
+            self.ispyb = StoreRotationInIspyb(self.ispyb_config, self.params, dcgid)
             self.last_sample_id = self.params.hyperion_params.ispyb_params.sample_id
         self.ispyb_ids: IspybIds = IspybIds()
         ISPYB_LOGGER.info("ISPYB handler received start document.")

--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -74,4 +74,5 @@ class RotationISPyBCallback(BaseISPyBCallback):
 
     def activity_gated_stop(self, doc: dict):
         if doc.get("run_start") == self.uid_to_finalize_on:
+            self.uid_to_finalize_on = None
             super().activity_gated_stop(doc)

--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from hyperion.external_interaction.callbacks.ispyb_callback_base import (
     BaseISPyBCallback,
 )
@@ -12,6 +14,9 @@ from hyperion.parameters.constants import ROTATION_OUTER_PLAN, ROTATION_PLAN_MAI
 from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
     RotationInternalParameters,
 )
+
+if TYPE_CHECKING:
+    from event_model.documents.event import Event
 
 
 class RotationISPyBCallback(BaseISPyBCallback):
@@ -31,6 +36,10 @@ class RotationISPyBCallback(BaseISPyBCallback):
     Usually used as part of a RotationCallbackCollection.
     """
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_sample_id: str | None = None
+
     def append_to_comment(self, comment: str):
         assert isinstance(self.ispyb_ids.data_collection_ids, int)
         self._append_to_comment(self.ispyb_ids.data_collection_ids, comment)
@@ -42,15 +51,24 @@ class RotationISPyBCallback(BaseISPyBCallback):
             )
             json_params = doc.get("hyperion_internal_parameters")
             self.params = RotationInternalParameters.from_json(json_params)
-            self.ispyb: StoreRotationInIspyb = StoreRotationInIspyb(
-                self.ispyb_config, self.params
+            dcgid = (
+                self.ispyb_ids.data_collection_group_id
+                if (
+                    self.params.hyperion_params.ispyb_params.sample_id
+                    == self.last_sample_id
+                )
+                else None
             )
+            self.ispyb: StoreRotationInIspyb = StoreRotationInIspyb(
+                self.ispyb_config, self.params, dcgid
+            )
+            self.last_sample_id = self.params.hyperion_params.ispyb_params.sample_id
         self.ispyb_ids: IspybIds = IspybIds()
         ISPYB_LOGGER.info("ISPYB handler received start document.")
         if doc.get("subplan_name") == ROTATION_PLAN_MAIN:
             self.uid_to_finalize_on = doc.get("uid")
 
-    def activity_gated_event(self, doc: dict):
+    def activity_gated_event(self, doc: Event):
         super().activity_gated_event(doc)
         set_dcgid_tag(self.ispyb_ids.data_collection_group_id)
 

--- a/src/hyperion/external_interaction/ispyb/store_datacollection_in_ispyb.py
+++ b/src/hyperion/external_interaction/ispyb/store_datacollection_in_ispyb.py
@@ -250,7 +250,7 @@ class StoreRotationInIspyb(StoreInIspyb):
         self,
         ispyb_config,
         parameters: RotationInternalParameters,
-        dcgid: int | None = None,
+        datacollection_group_id: int | None = None,
     ) -> None:
         super().__init__(ispyb_config, "SAD")
         self.full_params: RotationInternalParameters = parameters
@@ -261,7 +261,7 @@ class StoreRotationInIspyb(StoreInIspyb):
         )  # type:ignore # the validator always makes this int
         self.omega_start = self.detector_params.omega_start
         self.data_collection_id: int | None = None
-        self.data_collection_group_id = dcgid
+        self.data_collection_group_id = datacollection_group_id
 
         if self.ispyb_params.xtal_snapshots_omega_start:
             self.xtal_snapshots = self.ispyb_params.xtal_snapshots_omega_start[:3]

--- a/src/hyperion/external_interaction/ispyb/store_datacollection_in_ispyb.py
+++ b/src/hyperion/external_interaction/ispyb/store_datacollection_in_ispyb.py
@@ -53,7 +53,7 @@ class StoreInIspyb(ABC):
         self.run_number: int
         self.omega_start: float
         self.xtal_snapshots: list[str]
-        self.data_collection_group_id: int
+        self.data_collection_group_id: int | None
 
     @abstractmethod
     def _store_scan_data(self, conn: Connector) -> tuple:
@@ -261,8 +261,7 @@ class StoreRotationInIspyb(StoreInIspyb):
         )  # type:ignore # the validator always makes this int
         self.omega_start = self.detector_params.omega_start
         self.data_collection_id: int | None = None
-        if dcgid:
-            self.data_collection_group_id = dcgid
+        self.data_collection_group_id = dcgid
 
         if self.ispyb_params.xtal_snapshots_omega_start:
             self.xtal_snapshots = self.ispyb_params.xtal_snapshots_omega_start[:3]

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -346,9 +346,11 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
     rotation_ispyb.return_value.begin_deposition.side_effect = random_ids
 
     test_cases = zip(
-        ["abc", "abc", "abc", "def", "abc", "def", "def"],
-        [False, True, True, False, False, False, True],
+        ["abc", "abc", "abc", "def", "abc", "def", "def", "xyz", "hij", "hij", "hij"],
+        [False, True, True, False, False, False, True, False, False, True, True],
     )
+
+    last_dcgid = None
 
     for sample_id, same_dcgid in test_cases:
         params.hyperion_params.ispyb_params.sample_id = sample_id
@@ -363,5 +365,8 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
 
         if same_dcgid:
             assert rotation_ispyb.call_args.args[2] is not None
+            assert rotation_ispyb.call_args.args[2] is last_dcgid
         else:
             assert rotation_ispyb.call_args.args[2] is None
+
+        last_dcgid = cb[0].ispyb_ids.data_collection_group_id

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -1,6 +1,4 @@
 import os
-from functools import partial
-from random import randrange
 from typing import Callable
 from unittest.mock import MagicMock, patch
 
@@ -323,15 +321,19 @@ def test_ispyb_handler_grabs_uid_from_main_plan_and_not_first_start_doc(
         RE(fake_rotation_scan(params, cb, after_open_do, after_main_do))
 
 
-def random_ids() -> IspybIds:
-    rand_100 = partial(randrange, 100)
-    return IspybIds(
-        data_collection_group_id=rand_100(),
-        data_collection_ids=(rand_100(), rand_100()),
-        grid_ids=None,
-    )
+ids = [
+    IspybIds(data_collection_group_id=23, data_collection_ids=45, grid_ids=None),
+    IspybIds(data_collection_group_id=24, data_collection_ids=48, grid_ids=None),
+    IspybIds(data_collection_group_id=25, data_collection_ids=51, grid_ids=None),
+    IspybIds(data_collection_group_id=26, data_collection_ids=111, grid_ids=None),
+    IspybIds(data_collection_group_id=27, data_collection_ids=238476, grid_ids=None),
+    IspybIds(data_collection_group_id=36, data_collection_ids=189765, grid_ids=None),
+    IspybIds(data_collection_group_id=39, data_collection_ids=0, grid_ids=None),
+    IspybIds(data_collection_group_id=43, data_collection_ids=89, grid_ids=None),
+]
 
 
+@pytest.mark.parametrize("ispyb_ids", ids)
 @patch(
     "hyperion.external_interaction.callbacks.rotation.ispyb_callback.StoreRotationInIspyb",
     autospec=True,
@@ -340,10 +342,11 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
     rotation_ispyb: MagicMock,
     RE: RunEngine,
     params: RotationInternalParameters,
+    ispyb_ids,
 ):
     cb = [RotationISPyBCallback()]
     cb[0].active = True
-    rotation_ispyb.return_value.begin_deposition.side_effect = random_ids
+    rotation_ispyb.return_value.begin_deposition.return_value = ispyb_ids
 
     test_cases = zip(
         ["abc", "abc", "abc", "def", "abc", "def", "def", "xyz", "hij", "hij", "hij"],

--- a/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
+++ b/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from random import randrange
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import numpy as np
@@ -209,16 +208,17 @@ def test_store_rotation_scan(
     )
 
 
+@pytest.mark.parametrize("dcgid", [2, 45, 61, 88, 13, 25])
 @patch("ispyb.open", new_callable=mock_open)
-def test_store_rotation_scan_uses_supplied_dcgid(ispyb_conn, dummy_rotation_params):
+def test_store_rotation_scan_uses_supplied_dcgid(
+    ispyb_conn, dummy_rotation_params, dcgid
+):
     ispyb_conn.return_value.mx_acquisition = MagicMock()
     ispyb_conn.return_value.core = mock()
-    for i in range(5):
-        dcgid = randrange(100)
-        store_in_ispyb = StoreRotationInIspyb(
-            SIM_ISPYB_CONFIG, dummy_rotation_params, dcgid
-        )
-        assert store_in_ispyb.begin_deposition().data_collection_group_id == dcgid
+    store_in_ispyb = StoreRotationInIspyb(
+        SIM_ISPYB_CONFIG, dummy_rotation_params, dcgid
+    )
+    assert store_in_ispyb.begin_deposition().data_collection_group_id == dcgid
 
 
 @patch("ispyb.open", new_callable=mock_open)

--- a/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
+++ b/tests/unit_tests/external_interaction/test_store_datacollection_in_ispyb.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from random import randrange
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import numpy as np
@@ -206,6 +207,18 @@ def test_store_rotation_scan(
         data_collection_ids=TEST_DATA_COLLECTION_IDS[0],
         data_collection_group_id=TEST_DATA_COLLECTION_GROUP_ID,
     )
+
+
+@patch("ispyb.open", new_callable=mock_open)
+def test_store_rotation_scan_uses_supplied_dcgid(ispyb_conn, dummy_rotation_params):
+    ispyb_conn.return_value.mx_acquisition = MagicMock()
+    ispyb_conn.return_value.core = mock()
+    for i in range(5):
+        dcgid = randrange(100)
+        store_in_ispyb = StoreRotationInIspyb(
+            SIM_ISPYB_CONFIG, dummy_rotation_params, dcgid
+        )
+        assert store_in_ispyb.begin_deposition().data_collection_group_id == dcgid
 
 
 @patch("ispyb.open", new_callable=mock_open)


### PR DESCRIPTION
Fixes #920 

`RotationIspybCallback` now holds on to the previous experiment's sampleID, and if the next one matches, reuses the DCGID for the ISPYB deposition

### To test:
1. Run tests
