### PR TITLE
Make ophyd pin tip detection more robust to false negatives

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@328330036a23cae8748e84a26eb9b77ad113f8a5
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@bede031f673c3468fe57ede1ef21905bbb74e6d5
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103

--- a/src/hyperion/device_setup_plans/setup_oav.py
+++ b/src/hyperion/device_setup_plans/setup_oav.py
@@ -4,7 +4,7 @@ from typing import Generator, Tuple
 import bluesky.plan_stubs as bps
 import numpy as np
 from bluesky.utils import Msg
-from dodal.devices.areadetector.plugins.MXSC import MXSC
+from dodal.devices.areadetector.plugins.MXSC import MXSC, PinTipDetect
 from dodal.devices.oav.oav_calculations import camera_coordinates_to_xyz
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
 from dodal.devices.oav.oav_errors import OAVError_ZoomLevelNotFound
@@ -174,37 +174,13 @@ def get_move_required_so_that_beam_is_at_pixel(
     return calculate_x_y_z_of_pixel(current_motor_xyz, current_angle, pixel, oav_params)
 
 
-def wait_for_tip_to_be_found_ad_mxsc(
-    mxsc: MXSC,
-) -> Generator[Msg, None, Tuple[int, int]]:
-    pin_tip = mxsc.pin_tip
-    yield from bps.trigger(pin_tip, wait=True)
-    found_tip = yield from bps.rd(pin_tip)
-    if found_tip == pin_tip.INVALID_POSITION:
-        top_edge = yield from bps.rd(mxsc.top)
-        bottom_edge = yield from bps.rd(mxsc.bottom)
-        LOGGER.info(
-            f"No tip found with top/bottom of {list(top_edge), list(bottom_edge)}"
-        )
-        raise WarningException(
-            f"No pin found after {pin_tip.validity_timeout.get()} seconds"
-        )
-    return found_tip
-
-
-def wait_for_tip_to_be_found_ophyd(
-    ophyd_pin_tip_detection: PinTipDetection,
-) -> Generator[Msg, None, Tuple[int, int]]:
+def wait_for_tip_to_be_found(
+    ophyd_pin_tip_detection: PinTipDetection | PinTipDetect,
+) -> Generator[Msg, None, Pixel]:
+    yield from bps.trigger(ophyd_pin_tip_detection, wait=True)
     found_tip = yield from bps.rd(ophyd_pin_tip_detection)
-
-    LOGGER.info("Pin tip not found, waiting a second and trying again")
-
     if found_tip == ophyd_pin_tip_detection.INVALID_POSITION:
-        # Wait a second and then retry
-        yield from bps.sleep(1)
-        found_tip = yield from bps.rd(ophyd_pin_tip_detection)
-
-    if found_tip == ophyd_pin_tip_detection.INVALID_POSITION:
-        raise WarningException("No pin found")
+        timeout = yield from bps.rd(ophyd_pin_tip_detection.validity_timeout)
+        raise WarningException(f"No pin found after {timeout} seconds")
 
     return found_tip  # type: ignore

--- a/src/hyperion/experiment_plans/oav_grid_detection_plan.py
+++ b/src/hyperion/experiment_plans/oav_grid_detection_plan.py
@@ -17,7 +17,7 @@ from dodal.devices.smargon import Smargon
 from hyperion.device_setup_plans.setup_oav import (
     get_move_required_so_that_beam_is_at_pixel,
     pre_centring_setup_oav,
-    wait_for_tip_to_be_found_ad_mxsc,
+    wait_for_tip_to_be_found,
 )
 from hyperion.log import LOGGER
 from hyperion.parameters.constants import (
@@ -114,7 +114,7 @@ def grid_detection_main_plan(
         # See #673 for improvements
         yield from bps.sleep(OAV_REFRESH_DELAY)
 
-        tip_x_px, tip_y_px = yield from wait_for_tip_to_be_found_ad_mxsc(oav.mxsc)
+        tip_x_px, tip_y_px = yield from wait_for_tip_to_be_found(oav.mxsc.pin_tip)
 
         LOGGER.info(f"Tip is at x,y: {tip_x_px},{tip_y_px}")
 

--- a/src/hyperion/experiment_plans/pin_tip_centring_plan.py
+++ b/src/hyperion/experiment_plans/pin_tip_centring_plan.py
@@ -5,7 +5,7 @@ import bluesky.plan_stubs as bps
 import numpy as np
 from blueapi.core import BlueskyContext
 from bluesky.utils import Msg
-from dodal.devices.areadetector.plugins.MXSC import MXSC, PinTipDetect
+from dodal.devices.areadetector.plugins.MXSC import PinTipDetect
 from dodal.devices.backlight import Backlight
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_parameters import OAV_CONFIG_JSON, OAVParameters
@@ -16,8 +16,7 @@ from hyperion.device_setup_plans.setup_oav import (
     Pixel,
     get_move_required_so_that_beam_is_at_pixel,
     pre_centring_setup_oav,
-    wait_for_tip_to_be_found_ad_mxsc,
-    wait_for_tip_to_be_found_ophyd,
+    wait_for_tip_to_be_found,
 )
 from hyperion.exceptions import WarningException
 from hyperion.log import LOGGER
@@ -44,17 +43,8 @@ def create_devices(context: BlueskyContext) -> PinTipCentringComposite:
 def trigger_and_return_pin_tip(
     pin_tip: PinTipDetect | PinTipDetection,
 ) -> Generator[Msg, None, Pixel]:
-    if isinstance(pin_tip, PinTipDetection):
-        tip_x_y_px = yield from bps.rd(pin_tip)
-
-        if tip_x_y_px == pin_tip.INVALID_POSITION:
-            # Wait a second and then retry
-            LOGGER.info("Pin tip not found, waiting a second and trying again")
-            yield from bps.sleep(1)
-            tip_x_y_px = yield from bps.rd(pin_tip)
-    else:
-        yield from bps.trigger(pin_tip, wait=True)
-        tip_x_y_px = yield from bps.rd(pin_tip)
+    yield from bps.trigger(pin_tip, wait=True)
+    tip_x_y_px = yield from bps.rd(pin_tip)
     LOGGER.info(f"Pin tip found at {tip_x_y_px}")
     return tip_x_y_px  # type: ignore
 
@@ -197,10 +187,5 @@ def pin_tip_centre_plan(
     # See #673 for improvements
     yield from bps.sleep(0.3)
 
-    if isinstance(pin_tip_setup, MXSC):
-        LOGGER.info("Acquiring pin-tip from AD MXSC plugin")
-        tip = yield from wait_for_tip_to_be_found_ad_mxsc(pin_tip_setup)
-    elif isinstance(pin_tip_setup, PinTipDetection):
-        LOGGER.info("Acquiring pin-tip from ophyd device")
-        tip = yield from wait_for_tip_to_be_found_ophyd(pin_tip_setup)
+    tip = yield from wait_for_tip_to_be_found(pin_tip_detect)
     yield from offset_and_move(tip)

--- a/tests/unit_tests/device_setup_plans/test_utils.py
+++ b/tests/unit_tests/device_setup_plans/test_utils.py
@@ -20,7 +20,7 @@ def mock_eiger():
     return eiger
 
 
-class TestException(Exception):
+class MyTestException(Exception):
     pass
 
 
@@ -29,12 +29,12 @@ def test_given_plan_raises_when_exception_raised_then_eiger_disarmed_and_correct
 ):
     def my_plan():
         yield from bps.null()
-        raise TestException()
+        raise MyTestException()
 
     eiger = mock_eiger
     detector_motion = MagicMock()
 
-    with pytest.raises(TestException):
+    with pytest.raises(MyTestException):
         RE(
             start_preparing_data_collection_then_do_plan(
                 eiger, detector_motion, 100, my_plan()

--- a/tests/unit_tests/experiment_plans/test_grid_detection_plan.py
+++ b/tests/unit_tests/experiment_plans/test_grid_detection_plan.py
@@ -284,9 +284,7 @@ def test_when_grid_detection_plan_run_then_grid_detection_callback_gets_correct_
 )
 @patch("dodal.beamlines.beamline_utils.active_device_is_same_type", lambda a, b: True)
 @patch("bluesky.plan_stubs.sleep", new=MagicMock())
-@patch(
-    "hyperion.experiment_plans.oav_grid_detection_plan.wait_for_tip_to_be_found_ad_mxsc"
-)
+@patch("hyperion.experiment_plans.oav_grid_detection_plan.wait_for_tip_to_be_found")
 @patch("hyperion.experiment_plans.oav_grid_detection_plan.LOGGER")
 def test_when_detected_grid_has_odd_y_steps_then_add_a_y_step_and_shift_grid(
     fake_logger: MagicMock,

--- a/tests/unit_tests/experiment_plans/test_pin_tip_centring.py
+++ b/tests/unit_tests/experiment_plans/test_pin_tip_centring.py
@@ -104,7 +104,7 @@ def test_trigger_and_return_pin_tip_works_for_AD_pin_tip_detection(
 def test_trigger_and_return_pin_tip_works_for_ophyd_pin_tip_detection(
     ophyd_pin_tip_detection: PinTipDetection, RE: RunEngine
 ):
-    ophyd_pin_tip_detection._get_tip_position = AsyncMock(return_value=((100, 200), 0))
+    ophyd_pin_tip_detection._get_tip_position = AsyncMock(return_value=(100, 200))
     re_result = RE(trigger_and_return_pin_tip(ophyd_pin_tip_detection))
     assert re_result.plan_result == (100, 200)  # type: ignore
 
@@ -182,7 +182,7 @@ def return_pixel(pixel, *args):
 
 
 @patch(
-    "hyperion.experiment_plans.pin_tip_centring_plan.wait_for_tip_to_be_found_ad_mxsc",
+    "hyperion.experiment_plans.pin_tip_centring_plan.wait_for_tip_to_be_found",
     new=partial(return_pixel, (200, 200)),
 )
 @patch(
@@ -241,7 +241,7 @@ def test_when_pin_tip_centre_plan_called_then_expected_plans_called(
 
 
 @patch(
-    "hyperion.experiment_plans.pin_tip_centring_plan.wait_for_tip_to_be_found_ophyd",
+    "hyperion.experiment_plans.pin_tip_centring_plan.wait_for_tip_to_be_found",
     new=partial(return_pixel, (200, 200)),
 )
 @patch(


### PR DESCRIPTION
Fixes #1069

Link to dodal PR (if required): https://github.com/DiamondLightSource/dodal/pull/336

Notes (feel free to disagree):
* I believe the test removed here is covered in `dodal` by `test_given_find_tip_fails_twice_when_triggered_then_tip_invalid_and_tried_twice` trying to add it here would mean a lot of getting in the guts of `ophyd-async`, which I feel we should be somewhat removed from
* This does mean that we no longer log the edges of the pin when no tip is found. I thought that was worth it for the cleaner code. We will also get even better debugging with https://github.com/DiamondLightSource/dodal/issues/290 at some point anyway

### To test:
1. Confirm tests still pass and code cleaner
