### PR TITLE
(#1163) Fix for ispyb comment coordinates being wrong due to pixels-per-micron/microns-per-pixel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@490ea20ba214c481cc674a2773126c5dca1e59e4
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@8d25746e3407c8331357e8ce159e89c5d3bfee92
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103

--- a/tests/unit_tests/external_interaction/ispyb/conftest.py
+++ b/tests/unit_tests/external_interaction/ispyb/conftest.py
@@ -57,8 +57,8 @@ def dummy_params():
     dummy_params.hyperion_params.ispyb_params.sample_id = TEST_SAMPLE_ID
     dummy_params.hyperion_params.ispyb_params.sample_barcode = TEST_BARCODE
     dummy_params.hyperion_params.ispyb_params.upper_left = np.array([100, 100, 50])
-    dummy_params.hyperion_params.ispyb_params.microns_per_pixel_x = 0.8
-    dummy_params.hyperion_params.ispyb_params.microns_per_pixel_y = 0.8
+    dummy_params.hyperion_params.ispyb_params.microns_per_pixel_x = 1.25
+    dummy_params.hyperion_params.ispyb_params.microns_per_pixel_y = 1.25
     dummy_params.hyperion_params.detector_params.run_number = 0
     return dummy_params
 


### PR DESCRIPTION
Fixes #1163 

Link to dodal PR (if required): DiamondLightSource/dodal#346

### To test:
1. Comments in ispyb should now have the correct coordinate for the bottom-right which was previously incorrect
