### PR TITLE
Allow the ispyb experiment_type field to be populated by GDA

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@8d25746e3407c8331357e8ce159e89c5d3bfee92
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@00ef53ddf55c53fd000990c25ad6093e88f39fe4
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103

--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -74,7 +74,18 @@ class RotationISPyBCallback(BaseISPyBCallback):
                     f"Collection has {n_images} images - treating as a genuine dataset - storing sampleID to bundle images"
                 )
                 self.last_sample_id = self.params.hyperion_params.ispyb_params.sample_id
-            self.ispyb = StoreRotationInIspyb(self.ispyb_config, self.params, dcgid)
+            experiment_type = (
+                self.params.hyperion_params.ispyb_params.ispyb_experiment_type
+            )
+            if experiment_type:
+                self.ispyb = StoreRotationInIspyb(
+                    self.ispyb_config,
+                    self.params,
+                    dcgid,
+                    experiment_type,
+                )
+            else:
+                self.ispyb = StoreRotationInIspyb(self.ispyb_config, self.params, dcgid)
             ISPYB_LOGGER.info("Beginning ispyb deposition")
             self.ispyb_ids = self.ispyb.begin_deposition()
         ISPYB_LOGGER.info("ISPYB handler received start document.")

--- a/src/hyperion/external_interaction/ispyb/ispyb_dataclass.py
+++ b/src/hyperion/external_interaction/ispyb/ispyb_dataclass.py
@@ -63,6 +63,8 @@ class IspybParams(BaseModel):
     xtal_snapshots_omega_start: Optional[list[str]] = None
     xtal_snapshots_omega_end: Optional[list[str]] = None
 
+    ispyb_experiment_type: Optional[str] = None
+
     class Config:
         arbitrary_types_allowed = True
         json_encoders = {np.ndarray: lambda a: a.tolist()}

--- a/src/hyperion/external_interaction/ispyb/rotation_ispyb_store.py
+++ b/src/hyperion/external_interaction/ispyb/rotation_ispyb_store.py
@@ -22,8 +22,9 @@ class StoreRotationInIspyb(StoreInIspyb):
         ispyb_config,
         parameters: RotationInternalParameters,
         datacollection_group_id: int | None = None,
+        experiment_type: str = "SAD",
     ) -> None:
-        super().__init__(ispyb_config, "SAD")
+        super().__init__(ispyb_config, experiment_type)
         self.full_params: RotationInternalParameters = parameters
         self._ispyb_params: RotationIspybParams = (  # pyright: ignore
             parameters.hyperion_params.ispyb_params

--- a/src/hyperion/parameters/schemas/full_external_parameters_schema.json
+++ b/src/hyperion/parameters/schemas/full_external_parameters_schema.json
@@ -3,7 +3,7 @@
     "type": "object",
     "properties": {
         "params_version": {
-            "const": "4.0.3"
+            "const": "4.0.4"
         },
         "hyperion_params": {
             "type": "object",

--- a/src/hyperion/parameters/schemas/ispyb_parameters_schema.json
+++ b/src/hyperion/parameters/schemas/ispyb_parameters_schema.json
@@ -74,6 +74,9 @@
         },
         "resolution": {
             "type": "number"
+        },
+        "ispyb_experiment_type": {
+            "type": ["string", "null"]
         }
     },
     "required": [

--- a/tests/test_data/parameter_json_files/good_test_grid_with_edge_detect_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_grid_with_edge_detect_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_pin_centre_then_xray_centre_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_pin_centre_then_xray_centre_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_stepped_grid_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_stepped_grid_scan_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
+++ b/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "zocalo_environment": "artemis",
         "beamline": "BL03I",

--- a/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params_no_energy.json
+++ b/tests/test_data/parameter_json_files/good_test_wait_for_robot_load_params_no_energy.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "zocalo_environment": "artemis",
         "beamline": "BL03I",

--- a/tests/test_data/parameter_json_files/live_test_rotation_params.json
+++ b/tests/test_data/parameter_json_files/live_test_rotation_params.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03I",
         "insertion_prefix": "SR03I",

--- a/tests/test_data/parameter_json_files/live_test_rotation_params_move_xyz.json
+++ b/tests/test_data/parameter_json_files/live_test_rotation_params_move_xyz.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03I",
         "insertion_prefix": "SR03I",

--- a/tests/test_data/parameter_json_files/panda_test_parameters.json
+++ b/tests/test_data/parameter_json_files/panda_test_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03I",
         "insertion_prefix": "SR03I",

--- a/tests/test_data/parameter_json_files/test_internal_parameter_defaults.json
+++ b/tests/test_data/parameter_json_files/test_internal_parameter_defaults.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "zocalo_environment": "dev_artemis",
         "beamline": "BL03S",

--- a/tests/test_data/parameter_json_files/test_parameter_defaults.json
+++ b/tests/test_data/parameter_json_files/test_parameter_defaults.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "zocalo_environment": "dev_artemis",
         "beamline": "BL03S",

--- a/tests/test_data/parameter_json_files/test_parameters.json
+++ b/tests/test_data/parameter_json_files/test_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "4.0.3",
+    "params_version": "4.0.4",
     "hyperion_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -370,6 +370,9 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
 ):
     cb = [RotationISPyBCallback()]
     cb[0].active = True
+    ispyb_ids = IspybIds(
+        data_collection_group_id=23, data_collection_ids=45, grid_ids=None
+    )
     rotation_ispyb.return_value.begin_deposition.return_value = ispyb_ids
 
     test_cases = zip(
@@ -397,6 +400,30 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
             assert rotation_ispyb.call_args.args[2] is None
 
         last_dcgid = cb[0].ispyb_ids.data_collection_group_id
+
+
+@patch(
+    "hyperion.external_interaction.callbacks.rotation.ispyb_callback.StoreRotationInIspyb",
+    autospec=True,
+)
+def test_ispyb_specifies_experiment_type_if_supplied(
+    rotation_ispyb: MagicMock,
+    RE: RunEngine,
+    params: RotationInternalParameters,
+):
+    cb = [RotationISPyBCallback()]
+    cb[0].active = True
+    params.hyperion_params.ispyb_params.ispyb_experiment_type = "Characterization"
+    rotation_ispyb.return_value.begin_deposition.return_value = IspybIds(
+        data_collection_group_id=23, data_collection_ids=45, grid_ids=None
+    )
+
+    params.hyperion_params.ispyb_params.sample_id = "abc"
+
+    RE(fake_rotation_scan(params, cb))
+
+    assert rotation_ispyb.call_args.args[3] == "Characterization"
+    assert rotation_ispyb.call_args.args[2] is None
 
 
 n_images_store_id = [


### PR DESCRIPTION
Fixes #1182

Link to dodal PR (if required): #N/A
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
* ispyb experiment_type field should now be populated via the `ispyb_params.ispyb_experiment_type` field as specified by the call from GDA (for rotation scans)
* For gridscans it will be left as "mesh" or "Mesh3D" as appropriate, and if unspecified for rotation scans it will be "SAD"
