### PR TITLE
1186 fix start log

### DIFF
--- a/run_hyperion.sh
+++ b/run_hyperion.sh
@@ -112,8 +112,8 @@ if [[ $START == 1 ]]; then
     echo "$(date) Logging to $HYPERION_LOG_DIR"
     export HYPERION_LOG_DIR
     mkdir -p $HYPERION_LOG_DIR
-    start_log_path=$HYPERION_LOG_DIR/start_log.txt
-    callback_start_log_path=$HYPERION_LOG_DIR/callback_start_log.txt
+    start_log_path=$HYPERION_LOG_DIR/start_log.log
+    callback_start_log_path=$HYPERION_LOG_DIR/callback_start_log.log
 
     source .venv/bin/activate
 
@@ -145,11 +145,10 @@ if [[ $START == 1 ]]; then
     done
 
     unset PYEPICS_LIBCA
-    screen -S hyperion-debug -d -m hyperion `echo $h_commands;`>$start_log_path &
+    hyperion `echo $h_commands;`>$start_log_path  2>&1 &
     if [ $EXTERNAL_CALLBACK_SERVICE == true ]; then
         hyperion-callbacks `echo $cb_commands;`>$callback_start_log_path 2>&1 &
     fi
-
     echo "$(date) Waiting for Hyperion to start"
 
     for i in {1..30}

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@00ef53ddf55c53fd000990c25ad6093e88f39fe4
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@f7dad0203d3d801df498ec1b2ee3d56945d15aab
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103


### PR DESCRIPTION
Fixes #1186 

Removes the use of `screen` to run hyperion so that `start_log` is written correctly. Inspection of debug logs can be addressed in #1191 

### To test:
1. run `./run_hyperion --dev` in a terminal with `BEAMLINE` unset and see that the exception is written