### PR TITLE
Use ophyd oav edge detetion for grid determination

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@54af3ccf31a1570dc4bdb0d365f8696a3d130d92
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@f51ec5aa4a258a960e70a894cf93e3061ab3c893
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@f51ec5aa4a258a960e70a894cf93e3061ab3c893
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@e5e629eec30f8aa1ef9edb5de0475cfcdb68365f
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103

--- a/src/hyperion/device_setup_plans/setup_oav.py
+++ b/src/hyperion/device_setup_plans/setup_oav.py
@@ -133,7 +133,8 @@ def pre_centring_setup_oav(
     )
 
     # Connect MXSC output to MJPG input for debugging
-    yield from set_using_group(oav.snapshot.input_plugin, "OAV.MXSC")
+    if isinstance(pin_tip_detection_device, MXSC):
+        yield from set_using_group(oav.snapshot.input_plugin, "OAV.MXSC")
 
     yield from bps.wait(oav_group)
 

--- a/src/hyperion/device_setup_plans/setup_oav.py
+++ b/src/hyperion/device_setup_plans/setup_oav.py
@@ -178,7 +178,7 @@ def wait_for_tip_to_be_found(
     ophyd_pin_tip_detection: PinTipDetection | PinTipDetect,
 ) -> Generator[Msg, None, Pixel]:
     yield from bps.trigger(ophyd_pin_tip_detection, wait=True)
-    found_tip = yield from bps.rd(ophyd_pin_tip_detection)
+    found_tip = yield from bps.rd(ophyd_pin_tip_detection.triggered_tip)
     if found_tip == ophyd_pin_tip_detection.INVALID_POSITION:
         timeout = yield from bps.rd(ophyd_pin_tip_detection.validity_timeout)
         raise WarningException(f"No pin found after {timeout} seconds")

--- a/src/hyperion/experiment_plans/oav_grid_detection_plan.py
+++ b/src/hyperion/experiment_plans/oav_grid_detection_plan.py
@@ -8,7 +8,6 @@ import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 import numpy as np
 from blueapi.core import BlueskyContext
-from bluesky.preprocessors import finalize_wrapper
 from dodal.devices.backlight import Backlight
 from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
@@ -17,8 +16,8 @@ from dodal.devices.smargon import Smargon
 from hyperion.device_setup_plans.setup_oav import (
     get_move_required_so_that_beam_is_at_pixel,
     pre_centring_setup_oav,
-    wait_for_tip_to_be_found,
 )
+from hyperion.experiment_plans.pin_tip_centring_plan import trigger_and_return_pin_tip
 from hyperion.log import LOGGER
 from hyperion.parameters.constants import (
     OAV_REFRESH_DELAY,
@@ -43,29 +42,8 @@ def create_devices(context: BlueskyContext) -> OavGridDetectionComposite:
     return device_composite_from_context(context, OavGridDetectionComposite)
 
 
-def grid_detection_plan(
-    composite: OavGridDetectionComposite,
-    parameters: OAVParameters,
-    snapshot_template: str,
-    snapshot_dir: str,
-    grid_width_microns: float,
-    box_size_microns=20,
-):
-    yield from finalize_wrapper(
-        grid_detection_main_plan(
-            composite,
-            parameters,
-            snapshot_template,
-            snapshot_dir,
-            grid_width_microns,
-            box_size_microns,
-        ),
-        reset_oav(composite.oav),
-    )
-
-
 @bpp.run_decorator()
-def grid_detection_main_plan(
+def grid_detection_plan(
     composite: OavGridDetectionComposite,
     parameters: OAVParameters,
     snapshot_template: str,
@@ -87,13 +65,14 @@ def grid_detection_main_plan(
     """
     oav: OAV = composite.oav
     smargon: Smargon = composite.smargon
+    pin_tip_detection: PinTipDetection = composite.pin_tip_detection
 
     LOGGER.info("OAV Centring: Starting grid detection centring")
 
     yield from bps.wait()
 
     # Set relevant PVs to whatever the config dictates.
-    yield from pre_centring_setup_oav(oav, parameters, oav.mxsc)
+    yield from pre_centring_setup_oav(oav, parameters, pin_tip_detection)
 
     LOGGER.info("OAV Centring: Camera set up")
 
@@ -113,13 +92,14 @@ def grid_detection_main_plan(
         # need to wait for the OAV image to update
         # See #673 for improvements
         yield from bps.sleep(OAV_REFRESH_DELAY)
-
-        tip_x_px, tip_y_px = yield from wait_for_tip_to_be_found(oav.mxsc.pin_tip)
+        tip_x_px, tip_y_px = yield from trigger_and_return_pin_tip(pin_tip_detection)
 
         LOGGER.info(f"Tip is at x,y: {tip_x_px},{tip_y_px}")
 
-        top_edge = np.array((yield from bps.rd(oav.mxsc.top)))
-        bottom_edge = np.array((yield from bps.rd(oav.mxsc.bottom)))
+        top_edge = np.array((yield from bps.rd(pin_tip_detection.triggered_top_edge)))
+        bottom_edge = np.array(
+            (yield from bps.rd(pin_tip_detection.triggered_bottom_edge))
+        )
 
         full_image_height_px = yield from bps.rd(oav.cam.array_size.array_size_y)
 
@@ -198,9 +178,3 @@ def grid_detection_main_plan(
     )
 
     LOGGER.info(f"Step sizes: {box_size_um, box_size_um, box_size_um}")
-
-
-def reset_oav(oav: OAV):
-    """Changes the MJPG stream to look at the camera without the edge detection and turns off the edge detcetion plugin."""
-    yield from bps.abs_set(oav.snapshot.input_plugin, "OAV.CAM")
-    yield from bps.abs_set(oav.mxsc.enable_callbacks, 0)

--- a/src/hyperion/experiment_plans/oav_grid_detection_plan.py
+++ b/src/hyperion/experiment_plans/oav_grid_detection_plan.py
@@ -16,9 +16,8 @@ from dodal.devices.smargon import Smargon
 from hyperion.device_setup_plans.setup_oav import (
     get_move_required_so_that_beam_is_at_pixel,
     pre_centring_setup_oav,
+    wait_for_tip_to_be_found,
 )
-from hyperion.exceptions import WarningException
-from hyperion.experiment_plans.pin_tip_centring_plan import trigger_and_return_pin_tip
 from hyperion.log import LOGGER
 from hyperion.parameters.constants import (
     OAV_REFRESH_DELAY,
@@ -93,10 +92,8 @@ def grid_detection_plan(
         # need to wait for the OAV image to update
         # See #673 for improvements
         yield from bps.sleep(OAV_REFRESH_DELAY)
-        tip_x_px, tip_y_px = yield from trigger_and_return_pin_tip(pin_tip_detection)
-        if tip_x_px is None or tip_y_px is None:
-            timeout = yield from bps.rd(pin_tip_detection.validity_timeout)
-            raise WarningException(f"No pin found after {timeout} seconds")
+
+        tip_x_px, tip_y_px = yield from wait_for_tip_to_be_found(pin_tip_detection)
 
         LOGGER.info(f"Tip is at x,y: {tip_x_px},{tip_y_px}")
 

--- a/src/hyperion/experiment_plans/pin_tip_centring_plan.py
+++ b/src/hyperion/experiment_plans/pin_tip_centring_plan.py
@@ -44,7 +44,7 @@ def trigger_and_return_pin_tip(
     pin_tip: PinTipDetect | PinTipDetection,
 ) -> Generator[Msg, None, Pixel]:
     yield from bps.trigger(pin_tip, wait=True)
-    tip_x_y_px = yield from bps.rd(pin_tip)
+    tip_x_y_px = yield from bps.rd(pin_tip.triggered_tip)
     LOGGER.info(f"Pin tip found at {tip_x_y_px}")
     return tip_x_y_px  # type: ignore
 

--- a/tests/unit_tests/device_setup_plans/test_setup_oav.py
+++ b/tests/unit_tests/device_setup_plans/test_setup_oav.py
@@ -93,7 +93,7 @@ def test_when_set_up_oav_with_different_zoom_levels_then_flat_field_applied_corr
     RE = RunEngine()
     RE(pre_centring_setup_oav(oav, mock_parameters, ophyd_pin_tip_detection))
     assert oav.mxsc.input_plugin.get() == expected_plugin
-    assert oav.snapshot.input_plugin.get() == "OAV.MXSC"
+    assert oav.snapshot.input_plugin.get() == expected_plugin
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/device_setup_plans/test_setup_oav.py
+++ b/tests/unit_tests/device_setup_plans/test_setup_oav.py
@@ -1,6 +1,7 @@
 from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 from bluesky import plan_stubs as bps
 from bluesky.run_engine import RunEngine
@@ -8,6 +9,7 @@ from dodal.beamlines import i03
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
+from dodal.devices.oav.pin_image_recognition.utils import SampleLocation
 from dodal.devices.smargon import Smargon
 from ophyd.signal import Signal
 from ophyd.sim import instantiate_fake_device
@@ -157,11 +159,13 @@ async def test_given_tip_found_when_wait_for_tip_to_be_found_called_then_tip_imm
         PinTipDetection, name="pin_detect"
     )
     await mock_pin_tip_detect.connect(sim=True)
-    mock_pin_tip_detect._get_tip_position = AsyncMock(return_value=(100, 100))
+    mock_pin_tip_detect._get_tip_and_edge_data = AsyncMock(
+        return_value=SampleLocation(100, 100, np.array([]), np.array([]))
+    )
     RE = RunEngine(call_returns_result=True)
     result = RE(wait_for_tip_to_be_found(mock_pin_tip_detect))
     assert result.plan_result == (100, 100)  # type: ignore
-    mock_pin_tip_detect._get_tip_position.assert_called_once()
+    mock_pin_tip_detect._get_tip_and_edge_data.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -171,8 +175,10 @@ async def test_given_no_tip_when_wait_for_tip_to_be_found_called_then_exception_
     )
     await mock_pin_tip_detect.connect(sim=True)
     await mock_pin_tip_detect.validity_timeout.set(0.2)
-    mock_pin_tip_detect._get_tip_position = AsyncMock(
-        return_value=(PinTipDetection.INVALID_POSITION)
+    mock_pin_tip_detect._get_tip_and_edge_data = AsyncMock(
+        return_value=SampleLocation(
+            *PinTipDetection.INVALID_POSITION, np.array([]), np.array([])
+        )
     )
     RE = RunEngine(call_returns_result=True)
     with pytest.raises(WarningException):

--- a/tests/unit_tests/experiment_plans/test_pin_centre_then_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_pin_centre_then_xray_centre_plan.py
@@ -4,6 +4,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.utils import Msg
 from dodal.devices.detector.detector_motion import ShutterState
+from dodal.devices.fast_grid_scan import GridScanParams
 
 from hyperion.experiment_plans.pin_centre_then_xray_centre_plan import (
     create_parameters_for_grid_detection,
@@ -71,16 +72,52 @@ def test_when_pin_centre_xray_centre_called_then_plan_runs_correctly(
 
 
 @patch(
+    "hyperion.experiment_plans.grid_detect_then_xray_centre_plan.GridDetectionCallback",
+)
+@patch(
+    "hyperion.experiment_plans.grid_detect_then_xray_centre_plan.OavSnapshotCallback",
+)
+@patch(
     "hyperion.experiment_plans.pin_centre_then_xray_centre_plan.pin_tip_centre_plan",
     autospec=True,
 )
+@patch(
+    "hyperion.experiment_plans.grid_detect_then_xray_centre_plan.grid_detection_plan",
+    autospec=True,
+)
 def test_when_pin_centre_xray_centre_called_then_detector_positioned(
+    mock_grid_detect: MagicMock,
     mock_pin_tip_centre: MagicMock,
+    mock_oav_callback: MagicMock,
+    mock_grid_callback: MagicMock,
     test_pin_centre_then_xray_centre_params: PinCentreThenXrayCentreInternalParameters,
     simple_beamline,
     test_config_files,
     sim_run_engine,
 ):
+
+    mock_oav_callback.return_value.out_upper_left = [[1, 3], [3, 4]]
+    mock_oav_callback.return_value.snapshot_filenames = [
+        ["1.png", "2.png", "3.png"],
+        ["1.png", "2.png", "3.png"],
+        ["1.png", "2.png", "3.png"],
+    ]
+    mock_grid_callback.return_value.get_grid_parameters.return_value = GridScanParams(
+        dwell_time_ms=0,
+        x_start=0,
+        y1_start=0,
+        y2_start=0,
+        z1_start=0,
+        z2_start=0,
+        x_steps=0,
+        y_steps=0,
+        z_steps=0,
+        x_step_size=0,
+        y_step_size=0,
+        z_step_size=0,
+        set_stub_offsets=False,
+    )
+
     sim_run_engine.add_handler_for_callback_subscribes()
     add_simple_pin_tip_centre_handlers(sim_run_engine)
     add_simple_oav_mxsc_callback_handlers(sim_run_engine)

--- a/tests/unit_tests/experiment_plans/test_pin_tip_centring.py
+++ b/tests/unit_tests/experiment_plans/test_pin_tip_centring.py
@@ -1,12 +1,14 @@
 from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 from bluesky.plan_stubs import null
-from bluesky.run_engine import RunEngine
+from bluesky.run_engine import RunEngine, RunEngineResult
 from dodal.devices.areadetector.plugins.MXSC import MXSC
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
 from dodal.devices.oav.pin_image_recognition import PinTipDetection
+from dodal.devices.oav.pin_image_recognition.utils import SampleLocation
 from dodal.devices.smargon import Smargon
 from ophyd.sim import NullStatus
 
@@ -39,6 +41,7 @@ def test_given_the_pin_tip_is_already_in_view_when_get_tip_into_view_then_tip_re
 
     oav.mxsc.pin_tip.trigger.assert_called_once()
     assert smargon.x.user_readback.get() == 0
+    assert isinstance(result, RunEngineResult)
     assert result.plan_result == (100, 200)
 
 
@@ -63,6 +66,7 @@ def test_given_no_tip_found_but_will_be_found_when_get_tip_into_view_then_smargo
     result = RE(move_pin_into_view(oav.mxsc.pin_tip, smargon))
 
     assert smargon.x.user_readback.get() == DEFAULT_STEP_SIZE
+    assert isinstance(result, RunEngineResult)
     assert result.plan_result == (100, 200)
 
 
@@ -104,7 +108,10 @@ def test_trigger_and_return_pin_tip_works_for_AD_pin_tip_detection(
 def test_trigger_and_return_pin_tip_works_for_ophyd_pin_tip_detection(
     ophyd_pin_tip_detection: PinTipDetection, RE: RunEngine
 ):
-    ophyd_pin_tip_detection._get_tip_position = AsyncMock(return_value=(100, 200))
+    mock_trigger_result = SampleLocation(100, 200, np.array([]), np.array([]))
+    ophyd_pin_tip_detection._get_tip_and_edge_data = AsyncMock(
+        return_value=mock_trigger_result
+    )
     re_result = RE(trigger_and_return_pin_tip(ophyd_pin_tip_detection))
     assert re_result.plan_result == (100, 200)  # type: ignore
 


### PR DESCRIPTION
Fixes #1068 and maybe #1213

Link to dodal PR: #https://github.com/DiamondLightSource/dodal/pull/358

Once we are confident in this change we should remove the resulting dead code: https://github.com/DiamondLightSource/hyperion/issues/1219

Tested on beamline and seems to work:
https://graylog2.diamond.ac.uk/streams/631745613d8af00a49bfee55/search?rangetype=absolute&fields=message%2Csource&width=1500&highlightMessage=&from=2024-03-05T13%3A41%3A38.000Z&to=2024-03-05T13%3A41%3A44.000Z&q=
https://ispyb.diamond.ac.uk/dc/visit/cm37235-1/dcg/11423343

### To test:
1. Run tests
