### PR TITLE
Speed up the unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import sys
+import threading
 from functools import partial
 from os import environ, getenv
 from typing import Callable, Generator, Optional, Sequence
@@ -130,8 +131,17 @@ def RE():
     yield RE
     try:
         RE.halt()
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Got exception while halting RunEngine {e}")
+    finally:
+        stopped_event = threading.Event()
+
+        def stop_event_loop():
+            RE.loop.stop()  # noqa: F821
+            stopped_event.set()
+
+        RE.loop.call_soon_threadsafe(stop_event_loop)
+        stopped_event.wait(10)
     del RE
 
 

--- a/tests/unit_tests/experiment_plans/test_grid_detection_plan.py
+++ b/tests/unit_tests/experiment_plans/test_grid_detection_plan.py
@@ -28,7 +28,7 @@ from ...conftest import RunEngineSimulator
 
 
 @pytest.fixture
-def fake_devices(smargon: Smargon, backlight: Backlight, test_config_files):
+def fake_devices(RE, smargon: Smargon, backlight: Backlight, test_config_files):
     oav = i03.oav(wait_for_connection=False, fake_with_ophyd_sim=True)
 
     oav.parameters = OAVConfigParams(

--- a/tests/unit_tests/experiment_plans/test_optimise_attenuation_plan.py
+++ b/tests/unit_tests/experiment_plans/test_optimise_attenuation_plan.py
@@ -42,7 +42,7 @@ def fake_create_devices() -> OptimizeAttenuationComposite:
     xspress3mini = i03.xspress3mini(fake_with_ophyd_sim=True, wait_for_connection=True)
     attenuator = i03.attenuator(fake_with_ophyd_sim=True, wait_for_connection=True)
     for device in attenuator.get_actual_filter_state_list():
-        device.sim_put(0)
+        device.sim_put(0)  # pyright: ignore
 
     return OptimizeAttenuationComposite(
         sample_shutter=sample_shutter, xspress3mini=xspress3mini, attenuator=attenuator

--- a/tests/unit_tests/experiment_plans/test_optimise_attenuation_plan.py
+++ b/tests/unit_tests/experiment_plans/test_optimise_attenuation_plan.py
@@ -41,6 +41,9 @@ def fake_create_devices() -> OptimizeAttenuationComposite:
     )
     xspress3mini = i03.xspress3mini(fake_with_ophyd_sim=True, wait_for_connection=True)
     attenuator = i03.attenuator(fake_with_ophyd_sim=True, wait_for_connection=True)
+    for device in attenuator.get_actual_filter_state_list():
+        device.sim_put(0)
+
     return OptimizeAttenuationComposite(
         sample_shutter=sample_shutter, xspress3mini=xspress3mini, attenuator=attenuator
     )


### PR DESCRIPTION
Unit tests were being slowed down, mainly by a series of exceptions thrown after completion in `test_optimise_attenuation_plan`, caused by a Status timeout. This fixes the issue by initialising the fake PV to the expected value, causing the dodal device set not to time out.

It is still unclear what is the primary cause of the delay, but there seems to be a ~0.5s penalty for every exception reported on the RunEngine, and several other cases where exceptions are thrown after a test completes successfully, however none as significant as this.

On my machine, the following speedup was obtained:
Before fix, tests tooks
66.19, 65.47, 65.60 seconds

After fix:
29.38, 29.61, 29.60 seconds

The other fix here is to ensure that the RunEngine event loop is properly shut down after use. Unfortunately this doesn't seem to have any significant impact on performance.
