### PR TITLE
Update pip and install wheel before environment setup

### DIFF
--- a/dls_dev_env.sh
+++ b/dls_dev_env.sh
@@ -14,6 +14,8 @@ mkdir .venv
 python -m venv .venv
 source .venv/bin/activate
 
+pip install --upgrade pip
+pip install wheel
 pip install -e .[dev]
 
 pre-commit install


### PR DESCRIPTION
Fixes #1224 

### To test:
1. Create a new env from this branch (using `dls_dev_env` and see that the warnings do not appear
