### PR TITLE
#1132 Remove need for metadata tag for logs

### DIFF
--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -62,7 +62,6 @@ from hyperion.parameters.constants import (
     GRIDSCAN_AND_MOVE,
     GRIDSCAN_MAIN_PLAN,
     GRIDSCAN_OUTER_PLAN,
-    SET_LOG_UID_TAG,
     SIM_BEAMLINE,
     TRIGGER_ZOCALO_ON,
 )
@@ -355,7 +354,6 @@ def flyscan_xray_centre(
     @bpp.run_decorator(  # attach experiment metadata to the start document
         md={
             "subplan_name": GRIDSCAN_OUTER_PLAN,
-            SET_LOG_UID_TAG: True,
             TRIGGER_ZOCALO_ON: DO_FGS,
             "hyperion_internal_parameters": parameters.json(),
             "activate_callbacks": [

--- a/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
@@ -50,7 +50,6 @@ from hyperion.parameters.constants import (
     GRIDSCAN_AND_MOVE,
     GRIDSCAN_MAIN_PLAN,
     GRIDSCAN_OUTER_PLAN,
-    SET_LOG_UID_TAG,
     SIM_BEAMLINE,
     TRIGGER_ZOCALO_ON,
 )
@@ -281,7 +280,6 @@ def panda_flyscan_xray_centre(
     @bpp.run_decorator(  # attach experiment metadata to the start document
         md={
             "subplan_name": GRIDSCAN_OUTER_PLAN,
-            SET_LOG_UID_TAG: True,
             TRIGGER_ZOCALO_ON: DO_FGS,
             "hyperion_internal_parameters": parameters.json(),
             "activate_callbacks": [

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -43,7 +43,6 @@ from hyperion.log import LOGGER
 from hyperion.parameters.constants import (
     ROTATION_OUTER_PLAN,
     ROTATION_PLAN_MAIN,
-    SET_LOG_UID_TAG,
     TRIGGER_ZOCALO_ON,
 )
 from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
@@ -262,7 +261,6 @@ def rotation_scan(composite: RotationScanComposite, parameters: Any) -> MsgGener
     @bpp.run_decorator(  # attach experiment metadata to the start document
         md={
             "subplan_name": ROTATION_OUTER_PLAN,
-            SET_LOG_UID_TAG: True,
             TRIGGER_ZOCALO_ON: ROTATION_PLAN_MAIN,
             "hyperion_internal_parameters": parameters.json(),
             "activate_callbacks": [

--- a/src/hyperion/external_interaction/callbacks/__main__.py
+++ b/src/hyperion/external_interaction/callbacks/__main__.py
@@ -28,8 +28,7 @@ from hyperion.log import (
     ISPYB_LOGGER,
     NEXUS_LOGGER,
     _get_logging_dir,
-    dc_group_id_filter,
-    run_uid_filter,
+    tag_filter,
 )
 from hyperion.parameters.cli import parse_callback_dev_mode_arg
 from hyperion.parameters.constants import (
@@ -64,8 +63,7 @@ def setup_logging(dev_mode: bool):
                 dev_mode,
                 error_log_buffer_lines=ERROR_LOG_BUFFER_LINES,
             )
-            handlers["graylog_handler"].addFilter(dc_group_id_filter)
-            handlers["graylog_handler"].addFilter(run_uid_filter)
+            handlers["graylog_handler"].addFilter(tag_filter)
     log_info(f"Loggers initialised with dev_mode={dev_mode}")
     nexgen_logger = logging.getLogger("nexgen")
     nexgen_logger.parent = NEXUS_LOGGER

--- a/src/hyperion/external_interaction/callbacks/log_uid_tag_callback.py
+++ b/src/hyperion/external_interaction/callbacks/log_uid_tag_callback.py
@@ -1,19 +1,20 @@
 from bluesky.callbacks import CallbackBase
 from event_model import RunStart, RunStop
 
-from hyperion.log import run_uid_filter
+from hyperion.log import set_uid_tag
 
 
 class LogUidTaggingCallback(CallbackBase):
     def __init__(self) -> None:
+        """Sets the logging filter to add the outermost run uid to graylog messages"""
         self.run_uid = None
 
     def start(self, doc: RunStart):
         if self.run_uid is None:
             self.run_uid = doc.get("uid")
-            run_uid_filter.run_uid = self.run_uid
+            set_uid_tag(self.run_uid)
 
     def stop(self, doc: RunStop):
         if doc.get("run_start") == self.run_uid:
             self.run_uid = None
-            run_uid_filter.run_uid = None
+            set_uid_tag(None)

--- a/src/hyperion/external_interaction/callbacks/log_uid_tag_callback.py
+++ b/src/hyperion/external_interaction/callbacks/log_uid_tag_callback.py
@@ -2,7 +2,6 @@ from bluesky.callbacks import CallbackBase
 from event_model import RunStart, RunStop
 
 from hyperion.log import run_uid_filter
-from hyperion.parameters.constants import SET_LOG_UID_TAG
 
 
 class LogUidTaggingCallback(CallbackBase):
@@ -10,7 +9,7 @@ class LogUidTaggingCallback(CallbackBase):
         self.run_uid = None
 
     def start(self, doc: RunStart):
-        if doc.get(SET_LOG_UID_TAG):
+        if self.run_uid is None:
             self.run_uid = doc.get("uid")
             run_uid_filter.run_uid = self.run_uid
 

--- a/src/hyperion/log.py
+++ b/src/hyperion/log.py
@@ -2,7 +2,6 @@ import logging
 from os import environ
 from pathlib import Path
 from typing import Optional
-from uuid import uuid4
 
 from dodal.log import (
     ERROR_LOG_BUFFER_LINES,
@@ -24,36 +23,29 @@ NEXUS_LOGGER.setLevel(logging.DEBUG)
 ALL_LOGGERS = [LOGGER, ISPYB_LOGGER, NEXUS_LOGGER]
 
 
-class DCGIDFilter(logging.Filter):
+class ExperimentMetadataTagFilter(logging.Filter):
     dc_group_id: Optional[str] = None
+    run_uid: Optional[str] = None
 
     def filter(self, record):
         if self.dc_group_id:
             record.dc_group_id = self.dc_group_id
-        return True
-
-
-class RunUIDFilter(logging.Filter):
-    run_uid: Optional[str] = None
-
-    def filter(self, record):
         if self.run_uid:
             record.run_uid = self.run_uid
         return True
 
-    def create_and_set_new(self) -> str:
-        self.run_uid = str(uuid4())
-        return self.run_uid
 
-
-dc_group_id_filter = DCGIDFilter()
-run_uid_filter = RunUIDFilter()
+tag_filter = ExperimentMetadataTagFilter()
 
 
 def set_dcgid_tag(dcgid):
     """Set the datacollection group id as a tag on all subsequent log messages.
     Setting to None will remove the tag."""
-    dc_group_id_filter.dc_group_id = dcgid
+    tag_filter.dc_group_id = dcgid
+
+
+def set_uid_tag(uid):
+    tag_filter.run_uid = uid
 
 
 def do_default_logging_setup(dev_mode=False):
@@ -65,8 +57,7 @@ def do_default_logging_setup(dev_mode=False):
         ERROR_LOG_BUFFER_LINES,
     )
     integrate_bluesky_and_ophyd_logging(dodal_logger, handlers)
-    handlers["graylog_handler"].addFilter(dc_group_id_filter)
-    handlers["graylog_handler"].addFilter(run_uid_filter)
+    handlers["graylog_handler"].addFilter(tag_filter)
 
 
 def _get_logging_dir() -> Path:

--- a/src/hyperion/parameters/constants.py
+++ b/src/hyperion/parameters/constants.py
@@ -35,9 +35,6 @@ TRIGGER_ZOCALO_ON = "trigger_zocalo_on"
 ########################################################################################
 
 
-SET_LOG_UID_TAG = "set_log_uid_tag"
-
-
 class Actions(Enum):
     START = "start"
     STOP = "stop"

--- a/tests/unit_tests/hyperion/test_log/test_log.py
+++ b/tests/unit_tests/hyperion/test_log/test_log.py
@@ -13,7 +13,6 @@ from hyperion import log
 from hyperion.external_interaction.callbacks.log_uid_tag_callback import (
     LogUidTaggingCallback,
 )
-from hyperion.parameters.constants import SET_LOG_UID_TAG
 
 from .conftest import _destroy_loggers
 
@@ -92,11 +91,7 @@ def test_messages_are_tagged_with_run_uid(clear_and_mock_loggers, RE):
     test_run_uid = None
     logger = log.LOGGER
 
-    @bpp.run_decorator(
-        md={
-            SET_LOG_UID_TAG: True,
-        }
-    )
+    @bpp.run_decorator()
     def test_plan():
         yield from bps.sleep(0)
         assert log.run_uid_filter.run_uid is not None

--- a/tests/unit_tests/hyperion/test_log/test_log.py
+++ b/tests/unit_tests/hyperion/test_log/test_log.py
@@ -94,16 +94,16 @@ def test_messages_are_tagged_with_run_uid(clear_and_mock_loggers, RE):
     @bpp.run_decorator()
     def test_plan():
         yield from bps.sleep(0)
-        assert log.run_uid_filter.run_uid is not None
+        assert log.tag_filter.run_uid is not None
         nonlocal test_run_uid
-        test_run_uid = log.run_uid_filter.run_uid
+        test_run_uid = log.tag_filter.run_uid
         logger.info("test_hyperion")
         logger.info("test_hyperion")
         yield from bps.sleep(0)
 
-    assert log.run_uid_filter.run_uid is None
+    assert log.tag_filter.run_uid is None
     RE(test_plan())
-    assert log.run_uid_filter.run_uid is None
+    assert log.tag_filter.run_uid is None
 
     graylog_calls_in_plan = [
         c.args[0]


### PR DESCRIPTION

### To test:
1. See that `test_messages_are_tagged_with_run_uid` still passes even without the plan metadata