### PR TITLE
Speed up unit tests and fix some typing issues

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -49,7 +49,7 @@ jobs:
         run: diff-quality --violations=pyright --fail-under=100
 
       - name: Run tests
-        run: pytest -s --random-order -m "not (dlstbx or s03)"
+        run: pytest --logging -s --random-order -m "not (dlstbx or s03)"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python -m hyperion --skip-startup-connection
 
 Testing
 --------------
-Unit tests can be run with `python -m pytest -m "not s03" --random-order`. To see log output from tests you can use the `-s` command line option, and to set the logger levels to `DEBUG` rather than `INFO`, you can use the option `--debug-logging`. So to run the unit tests such that all logs are at `DEBUG` level and are printed to the terminal, you can use `python -m pytest -m "not s03" --random-order -s --debug-logging`. Note that this will likely overrun your terminal buffer, so you can narrow the selection of tests with the `-k "<test name pattern>"` option.
+Unit tests can be run with `python -m pytest -m "not s03" --random-order`. To see log output from tests you can turn on logging with the `--logging` command line option and then use the `-s` command line option to print logs into the console. So to run the unit tests such that all logs are at printed to the terminal, you can use `python -m pytest -m "not s03" --random-order --logging -s`. Note that this will likely overrun your terminal buffer, so you can narrow the selection of tests with the `-k "<test name pattern>"` option.
 
 To be able to run the system tests, or a complete fake scan, we need the simulated S03 beamline. This can be found at: https://gitlab.diamond.ac.uk/controls/python3/s03_utils
 

--- a/conftest.py
+++ b/conftest.py
@@ -17,10 +17,10 @@ if s03_epics_repeater_port:
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--debug-logging",
+        "--logging",
         action="store_true",
         default=False,
-        help="initialise test loggers in DEBUG instead of INFO",
+        help="Log during all tests (not just those that are testing logging logic)",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def _destroy_loggers(loggers):
 
 def pytest_runtest_setup(item):
     markers = [m.name for m in item.own_markers]
-    if "skip_log_setup" not in markers:
+    if item.config.getoption("logging") and "skip_log_setup" not in markers:
         if LOGGER.handlers == []:
             if dodal_logger.handlers == []:
                 print("Initialising Hyperion logger for tests")

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -305,19 +305,6 @@ def test_ispyb_handler_grabs_uid_from_main_plan_and_not_first_start_doc(
         RE(fake_rotation_scan(params, cb, after_open_do, after_main_do))
 
 
-ids = [
-    IspybIds(data_collection_group_id=23, data_collection_ids=(45,)),
-    IspybIds(data_collection_group_id=24, data_collection_ids=(48,)),
-    IspybIds(data_collection_group_id=25, data_collection_ids=(51,)),
-    IspybIds(data_collection_group_id=26, data_collection_ids=(111,)),
-    IspybIds(data_collection_group_id=27, data_collection_ids=(238476,)),
-    IspybIds(data_collection_group_id=36, data_collection_ids=(189765,)),
-    IspybIds(data_collection_group_id=39, data_collection_ids=(0,)),
-    IspybIds(data_collection_group_id=43, data_collection_ids=(89,)),
-]
-
-
-@pytest.mark.parametrize("ispyb_ids", ids)
 @patch(
     "hyperion.external_interaction.callbacks.rotation.ispyb_callback.StoreInIspyb",
     autospec=True,
@@ -326,7 +313,6 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
     rotation_ispyb: MagicMock,
     RE: RunEngine,
     params: RotationInternalParameters,
-    ispyb_ids,
 ):
     cb = [RotationISPyBCallback()]
     cb[0].active = True


### PR DESCRIPTION
Fixes #1220

* Removes logging by default, as discussed on issue
* Also speeds up a few other tests

### To test:
1. Run the tests with `pytest -m "not s03"`, confirm they all pass in ~30s
2. Confirm the tests in CI are still getting all the logs written to terminal