### PR TITLE
Make plan wait on FGS kickoff

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@97e3cdc11b1b5092c7f12ab6bc5ea1d702401b68
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@d9c104685cc8bbeab2f40ef9b86331958aa4bb53
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103

--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -201,7 +201,7 @@ def kickoff_and_complete_gridscan(
         LOGGER.info("Wait for all moves with no assigned group")
         yield from bps.wait()
         LOGGER.info("kicking off FGS")
-        yield from bps.kickoff(gridscan)
+        yield from bps.kickoff(gridscan, wait=True)
         LOGGER.info("Waiting for Zocalo device queue to have been cleared...")
         yield from bps.wait(
             ZOCALO_STAGE_GROUP

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -535,6 +535,7 @@ def fake_fgs_composite(
     )
 
     fake_composite.eiger.stage = MagicMock(return_value=done_status)
+    # unstage should be mocked on a per-test basis because several rely on unstage
     fake_composite.eiger.set_detector_parameters(
         test_fgs_params.hyperion_params.detector_params
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -493,6 +493,15 @@ def zocalo(done_status):
     return zoc
 
 
+def mock_gridscan_kickoff_complete(gridscan):
+    gridscan_start = DeviceStatus(device=gridscan)
+    gridscan_start.set_finished()
+    gridscan_result = GridScanCompleteStatus(device=gridscan)
+    gridscan_result.set_finished()
+    gridscan.kickoff = MagicMock(return_value=gridscan_start)
+    gridscan.complete = MagicMock(return_value=gridscan_result)
+
+
 @pytest.fixture
 def fake_fgs_composite(
     smargon: Smargon,
@@ -526,7 +535,6 @@ def fake_fgs_composite(
     )
 
     fake_composite.eiger.stage = MagicMock(return_value=done_status)
-    fake_composite.eiger.unstage = MagicMock(return_value=done_status)
     fake_composite.eiger.set_detector_parameters(
         test_fgs_params.hyperion_params.detector_params
     )
@@ -542,16 +550,9 @@ def fake_fgs_composite(
     fake_composite.aperture_scatterguard.scatterguard.y.user_setpoint._use_limits = (
         False
     )
-    gridscan_start = DeviceStatus(device=fake_composite.fast_grid_scan)
-    gridscan_start.set_finished()
-    gridscan_result = GridScanCompleteStatus(device=fake_composite.fast_grid_scan)
-    gridscan_result.set_finished()
-    fake_composite.fast_grid_scan.kickoff = MagicMock(return_value=gridscan_start)
-    fake_composite.fast_grid_scan.complete = MagicMock(return_value=gridscan_result)
-    fake_composite.panda_fast_grid_scan.kickoff = MagicMock(return_value=gridscan_start)
-    fake_composite.panda_fast_grid_scan.complete = MagicMock(
-        return_value=gridscan_result
-    )
+
+    mock_gridscan_kickoff_complete(fake_composite.fast_grid_scan)
+    mock_gridscan_kickoff_complete(fake_composite.panda_fast_grid_scan)
 
     test_result = {
         "centre_of_mass": [6, 6, 6],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,6 +526,7 @@ def fake_fgs_composite(
     )
 
     fake_composite.eiger.stage = MagicMock(return_value=done_status)
+    fake_composite.eiger.unstage = MagicMock(return_value=done_status)
     fake_composite.eiger.set_detector_parameters(
         test_fgs_params.hyperion_params.detector_params
     )

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -467,6 +467,7 @@ class TestFlyscanXrayCentrePlan:
         fake_fgs_composite: FlyScanXRayCentreComposite,
         done_status,
     ):
+        fake_fgs_composite.eiger.unstage = MagicMock(return_value=done_status)
         clear_device("fast_grid_scan")
         fgs = i03.fast_grid_scan(fake_with_ophyd_sim=True)
         fgs.KICKOFF_TIMEOUT = 0.1
@@ -737,10 +738,9 @@ class TestFlyscanXrayCentrePlan:
         fake_fgs_composite: FlyScanXRayCentreComposite,
         test_fgs_params: GridscanInternalParameters,
         RE: RunEngine,
+        done_status,
     ):
-        fake_fgs_composite.eiger.stage = MagicMock()
-        fake_fgs_composite.eiger.unstage = MagicMock()
-
+        fake_fgs_composite.eiger.unstage = MagicMock(return_value=done_status)
         RE(run_gridscan(fake_fgs_composite, test_fgs_params))
         fake_fgs_composite.eiger.stage.assert_called_once()
         fake_fgs_composite.eiger.unstage.assert_called_once()

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -7,6 +7,8 @@ import numpy as np
 import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.utils import FailedStatus
+from dodal.beamlines import i03
+from dodal.beamlines.beamline_utils import clear_device
 from dodal.devices.detector.det_dim_constants import (
     EIGER2_X_4M_DIMENSION,
     EIGER_TYPE_EIGER2_X_4M,
@@ -453,6 +455,53 @@ class TestFlyscanXrayCentrePlan:
         app_to_comment.assert_called()
         call = app_to_comment.call_args_list[0]
         assert "Crystal 1: Strength 999999" in call.args[1]
+
+    @patch(
+        "hyperion.experiment_plans.flyscan_xray_centre_plan.check_topup_and_wait_if_necessary",
+    )
+    def test_waits_for_motion_program(
+        self,
+        check_topup_and_wait,
+        RE,
+        test_fgs_params: GridscanInternalParameters,
+        fake_fgs_composite: FlyScanXRayCentreComposite,
+        done_status,
+    ):
+        clear_device("fast_grid_scan")
+        fgs = i03.fast_grid_scan(fake_with_ophyd_sim=True)
+        fgs.KICKOFF_TIMEOUT = 0.1
+        fgs.complete = MagicMock(return_value=done_status)
+        fgs.motion_program.running.sim_put(1)  # type: ignore
+        with pytest.raises(FailedStatus):
+            RE(
+                kickoff_and_complete_gridscan(
+                    fgs,
+                    fake_fgs_composite.eiger,
+                    fake_fgs_composite.synchrotron,
+                    "zocalo environment",
+                    [
+                        test_fgs_params.get_scan_points(1),
+                        test_fgs_params.get_scan_points(2),
+                    ],
+                )
+            )
+        fgs.KICKOFF_TIMEOUT = 1
+        fgs.motion_program.running.sim_put(0)  # type: ignore
+        fgs.status.sim_put(1)  # type: ignore
+        res = RE(
+            kickoff_and_complete_gridscan(
+                fgs,
+                fake_fgs_composite.eiger,
+                fake_fgs_composite.synchrotron,
+                "zocalo environment",
+                [
+                    test_fgs_params.get_scan_points(1),
+                    test_fgs_params.get_scan_points(2),
+                ],
+            )
+        )
+        assert res.exit_status == "success"
+        clear_device("fast_grid_scan")
 
     @patch(
         "hyperion.experiment_plans.flyscan_xray_centre_plan.run_gridscan", autospec=True

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -723,9 +723,9 @@ class TestFlyscanXrayCentrePlan:
         fake_fgs_composite: FlyScanXRayCentreComposite,
         test_panda_fgs_params: PandAGridscanInternalParameters,
         RE: RunEngine,
+        done_status,
     ):
-        fake_fgs_composite.eiger.stage = MagicMock()
-        fake_fgs_composite.eiger.unstage = MagicMock()
+        fake_fgs_composite.eiger.unstage = MagicMock(return_value=done_status)
 
         RE(run_gridscan(fake_fgs_composite, test_panda_fgs_params))
         fake_fgs_composite.eiger.stage.assert_called_once()


### PR DESCRIPTION
Fixes #1239 

The associated dodal change makes the FGS kickoff wait for there to be nothing running
This change makes the grid scan plan wait for the kickoff

Link to dodal PR (if required): [#380](https://github.com/DiamondLightSource/dodal/pull/380)


### To test:
1. Run tests
