### PR TITLE
Use event data for nexus writing

### DIFF
--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -208,8 +208,6 @@ def rotation_scan_plan(
         yield from bps.wait("setup_zebra")
 
         # get some information for the ispyb deposition and trigger the callback
-        yield from read_hardware_for_nexus_writer(composite.eiger)
-
         yield from read_hardware_for_zocalo(composite.eiger)
 
         yield from read_hardware_for_ispyb_pre_collection(
@@ -222,6 +220,7 @@ def rotation_scan_plan(
         yield from read_hardware_for_ispyb_during_collection(
             composite.attenuator, composite.flux, composite.dcm
         )
+        yield from read_hardware_for_nexus_writer(composite.eiger)
 
         # Get ready for the actual scan
         yield from bps.abs_set(

--- a/src/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
@@ -58,15 +58,21 @@ class RotationNexusFileCallback(PlanReactiveCallback):
                 "has no corresponding descriptor record"
             )
             return doc
+        if event_descriptor.get("name") == CONST.PLAN.ISPYB_TRANSMISSION_FLUX_READ:
+            NEXUS_LOGGER.info(f"Nexus handler received event from read hardware {doc}")
+            data = doc["data"]
+            assert self.writer, "Nexus writer not initialised"
+            self.writer.beam, self.writer.attenuator = (
+                create_beam_and_attenuator_parameters(
+                    data["dcm_energy_in_kev"],
+                    data["flux_flux_reading"],
+                    data["attenuator_actual_transmission"],
+                )
+            )
         if event_descriptor.get("name") == CONST.PLAN.NEXUS_READ:
             NEXUS_LOGGER.info(f"Nexus handler received event from read hardware {doc}")
             vds_data_type = vds_type_based_on_bit_depth(doc["data"]["eiger_bit_depth"])
             assert self.writer is not None
-            self.writer.beam, self.writer.attenuator = (
-                create_beam_and_attenuator_parameters(
-                    self.parameters.hyperion_params.ispyb_params
-                )
-            )
             self.writer.create_nexus_file(vds_data_type)
             NEXUS_LOGGER.info(f"Nexus file created at {self.writer.full_filename}")
         return doc

--- a/src/hyperion/external_interaction/callbacks/xray_centre/nexus_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/nexus_callback.py
@@ -16,7 +16,7 @@ from hyperion.parameters.plan_specific.gridscan_internal_params import (
 )
 
 if TYPE_CHECKING:
-    from event_model.documents import EventDescriptor, RunStart
+    from event_model.documents import Event, EventDescriptor, RunStart
 
 
 class GridscanNexusFileCallback(PlanReactiveCallback):
@@ -40,7 +40,6 @@ class GridscanNexusFileCallback(PlanReactiveCallback):
 
     def __init__(self) -> None:
         super().__init__(NEXUS_LOGGER)
-        self.parameters: GridscanInternalParameters | None = None
         self.run_start_uid: str | None = None
         self.nexus_writer_1: NexusWriter | None = None
         self.nexus_writer_2: NexusWriter | None = None
@@ -51,37 +50,39 @@ class GridscanNexusFileCallback(PlanReactiveCallback):
         if doc.get("subplan_name") == CONST.PLAN.GRIDSCAN_OUTER:
             json_params = doc.get("hyperion_internal_parameters")
             NEXUS_LOGGER.info(
-                f"Nexus writer recieved start document with experiment parameters {json_params}"
+                f"Nexus writer received start document with experiment parameters {json_params}"
             )
-            self.parameters = GridscanInternalParameters.from_json(json_params)
+            parameters = GridscanInternalParameters.from_json(json_params)
+            nexus_data_1 = parameters.get_nexus_info(1)
+            nexus_data_2 = parameters.get_nexus_info(2)
+            self.nexus_writer_1 = NexusWriter(parameters, **nexus_data_1)
+            self.nexus_writer_2 = NexusWriter(
+                parameters,
+                **nexus_data_2,
+                vds_start_index=nexus_data_1["data_shape"][0],
+            )
             self.run_start_uid = doc.get("uid")
 
     def activity_gated_descriptor(self, doc: EventDescriptor):
         self.descriptors[doc["uid"]] = doc
-        if doc.get("name") == CONST.PLAN.ISPYB_HARDWARE_READ:
-            assert (
-                self.parameters is not None
-            ), "Nexus callback did not receive parameters before being asked to write!"
-            # TODO instead of ispyb wait for detector parameter reading in plan
-            # https://github.com/DiamondLightSource/python-hyperion/issues/629
-            # and update parameters before creating writers
 
-            NEXUS_LOGGER.info("Initialising nexus writers...")
-            nexus_data_1 = self.parameters.get_nexus_info(1)
-            nexus_data_2 = self.parameters.get_nexus_info(2)
-            self.nexus_writer_1 = NexusWriter(self.parameters, **nexus_data_1)
-            self.nexus_writer_2 = NexusWriter(
-                self.parameters,
-                **nexus_data_2,
-                vds_start_index=nexus_data_1["data_shape"][0],
-            )
+    def activity_gated_event(self, doc: Event) -> Event | None:
+        event_descriptor = self.descriptors.get(doc["descriptor"])
+        if (
+            event_descriptor
+            and event_descriptor.get("name") == CONST.PLAN.ISPYB_TRANSMISSION_FLUX_READ
+        ):
+            data = doc["data"]
             for nexus_writer in [self.nexus_writer_1, self.nexus_writer_2]:
+                assert nexus_writer, "Nexus callback did not receive start doc"
                 nexus_writer.beam, nexus_writer.attenuator = (
                     create_beam_and_attenuator_parameters(
-                        self.parameters.hyperion_params.ispyb_params
+                        data["dcm_energy_in_kev"],
+                        data["flux_flux_reading"],
+                        data["attenuator_actual_transmission"],
                     )
                 )
                 nexus_writer.create_nexus_file()
-            NEXUS_LOGGER.info(
-                f"Nexus files created at {self.nexus_writer_1.full_filename} and {self.nexus_writer_1.full_filename}"
-            )
+                NEXUS_LOGGER.info(f"Nexus file created at {nexus_writer.full_filename}")
+
+        return super().activity_gated_event(doc)

--- a/src/hyperion/external_interaction/nexus/nexus_utils.py
+++ b/src/hyperion/external_interaction/nexus/nexus_utils.py
@@ -9,8 +9,8 @@ from nexgen.nxs_utils import Attenuator, Axis, Beam, Detector, EigerDetector, Go
 from nexgen.nxs_utils.Axes import TransformationType
 from numpy.typing import DTypeLike
 
-from hyperion.external_interaction.ispyb.ispyb_dataclass import IspybParams
 from hyperion.log import NEXUS_LOGGER
+from hyperion.utils.utils import convert_eV_to_angstrom
 
 
 def vds_type_based_on_bit_depth(detector_bit_depth: int) -> DTypeLike:
@@ -125,17 +125,14 @@ def create_detector_parameters(detector_params: DetectorParams) -> Detector:
 
 
 def create_beam_and_attenuator_parameters(
-    ispyb_params: IspybParams,
+    energy_kev: float, flux: float, transmission_fraction: float
 ) -> tuple[Beam, Attenuator]:
-    """Create beam and attenuator dictionaries that nexgen can understand.
-
-    Args:
-        ispyb_params (IspybParams): An IspybParams object holding all required data.
+    """Create beam and attenuator objects that nexgen can understands
 
     Returns:
         tuple[Beam, Attenuator]: Descriptions of the beam and attenuator for nexgen.
     """
     return (
-        Beam(ispyb_params.wavelength_angstroms, ispyb_params.flux),
-        Attenuator(ispyb_params.transmission_fraction),
+        Beam(convert_eV_to_angstrom(energy_kev * 1000), flux),
+        Attenuator(transmission_fraction),
     )

--- a/src/hyperion/external_interaction/nexus/write_nexus.py
+++ b/src/hyperion/external_interaction/nexus/write_nexus.py
@@ -7,15 +7,15 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
 from dodal.utils import get_beamline_name
-from nexgen.nxs_utils import Detector, Goniometer, Source
+from nexgen.nxs_utils import Attenuator, Beam, Detector, Goniometer, Source
 from nexgen.nxs_write.NXmxWriter import NXmxFileWriter
 from numpy.typing import DTypeLike
 
 from hyperion.external_interaction.nexus.nexus_utils import (
-    create_beam_and_attenuator_parameters,
     create_detector_parameters,
     create_goniometer_axes,
     get_start_and_predicted_end_time,
@@ -36,6 +36,8 @@ class NexusWriter:
         run_number: int | None = None,
         vds_start_index: int = 0,
     ) -> None:
+        self.beam: Optional[Beam] = None
+        self.attenuator: Optional[Attenuator] = None
         self.scan_points: dict = scan_points
         self.data_shape: tuple[int, int, int] = data_shape
         hyperion_parameters: HyperionParameters = (
@@ -52,9 +54,6 @@ class NexusWriter:
         )
         self.detector: Detector = create_detector_parameters(
             hyperion_parameters.detector_params
-        )
-        self.beam, self.attenuator = create_beam_and_attenuator_parameters(
-            hyperion_parameters.ispyb_params
         )
         self.source: Source = Source(get_beamline_name("S03"))
         self.directory: Path = Path(hyperion_parameters.detector_params.directory)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,7 +304,9 @@ def attenuator():
         return_value=Status(done=True, success=True),
         autospec=True,
     ):
-        yield i03.attenuator(fake_with_ophyd_sim=True)
+        attenuator = i03.attenuator(fake_with_ophyd_sim=True)
+        attenuator.actual_transmission.sim_put(0.49118047952)  # type: ignore
+        yield attenuator
 
 
 @pytest.fixture
@@ -318,6 +320,7 @@ def xbpm_feedback(done_status):
 @pytest.fixture
 def dcm():
     dcm = i03.dcm(fake_with_ophyd_sim=True)
+    dcm.energy_in_kev.user_readback.sim_put(12.7)  # type: ignore
     dcm.pitch_in_mrad.user_setpoint._use_limits = False
     dcm.dcm_roll_converter_lookup_table_path = (
         "tests/test_data/test_beamline_dcm_roll_converter.txt"
@@ -514,12 +517,13 @@ def fake_fgs_composite(
     xbpm_feedback,
     aperture_scatterguard,
     zocalo,
+    dcm,
 ):
     fake_composite = FlyScanXRayCentreComposite(
         aperture_scatterguard=aperture_scatterguard,
         attenuator=attenuator,
         backlight=i03.backlight(fake_with_ophyd_sim=True),
-        dcm=i03.dcm(fake_with_ophyd_sim=True),
+        dcm=dcm,
         # We don't use the eiger fixture here because .unstage() is used in some tests
         eiger=i03.eiger(fake_with_ophyd_sim=True),
         fast_grid_scan=i03.fast_grid_scan(fake_with_ophyd_sim=True),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,6 +292,7 @@ def ophyd_pin_tip_detection():
 
 @pytest.fixture
 def robot():
+    RunEngine()  # A RE is needed to start the bluesky loop
     robot = i03.robot(fake_with_ophyd_sim=True)
     set_sim_value(robot.barcode.bare_signal, ["BARCODE"])
     return robot

--- a/tests/unit_tests/external_interaction/nexus/test_write_nexus.py
+++ b/tests/unit_tests/external_interaction/nexus/test_write_nexus.py
@@ -8,6 +8,9 @@ import numpy as np
 import pytest
 from dodal.devices.fast_grid_scan import GridAxis, GridScanParams
 
+from hyperion.external_interaction.nexus.nexus_utils import (
+    create_beam_and_attenuator_parameters,
+)
 from hyperion.external_interaction.nexus.write_nexus import NexusWriter
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,
@@ -26,20 +29,22 @@ def assert_end_data_correct(nexus_writer: NexusWriter):
             assert "end_time_estimated" in entry
 
 
+def create_nexus_writer(parameters, writer_num):
+    nexus_writer = NexusWriter(parameters, **parameters.get_nexus_info(writer_num))
+    nexus_writer.beam, nexus_writer.attenuator = create_beam_and_attenuator_parameters(
+        parameters.hyperion_params.ispyb_params
+    )
+    return nexus_writer
+
+
 @pytest.fixture
 def dummy_nexus_writers(test_fgs_params: GridscanInternalParameters):
-    nexus_info_1 = test_fgs_params.get_nexus_info(1)
-    nexus_writer_1 = NexusWriter(test_fgs_params, **nexus_info_1)
-    nexus_info_2 = test_fgs_params.get_nexus_info(2)
-    nexus_writer_2 = NexusWriter(
-        test_fgs_params,
-        **nexus_info_2,
-        vds_start_index=nexus_info_1["data_shape"][0],
-    )
+    writers = [create_nexus_writer(test_fgs_params, i) for i in [1, 2]]
+    writers[1].start_index = test_fgs_params.get_nexus_info(1)["data_shape"][0]
 
-    yield nexus_writer_1, nexus_writer_2
+    yield writers
 
-    for writer in [nexus_writer_1, nexus_writer_2]:
+    for writer in writers:
         os.remove(writer.nexus_file)
         os.remove(writer.master_file)
 
@@ -51,13 +56,15 @@ def create_nexus_writers_with_many_images(parameters: GridscanInternalParameters
     parameters.experiment_params.y_steps = y
     parameters.experiment_params.z_steps = z
     parameters.hyperion_params.detector_params.num_triggers = x * y + x * z
-    nexus_writer_1 = NexusWriter(parameters, **parameters.get_nexus_info(1))
-    nexus_writer_2 = NexusWriter(parameters, **parameters.get_nexus_info(2))
+
+    writers = [create_nexus_writer(parameters, i) for i in [1, 2]]
+    writers[1].start_index = parameters.get_nexus_info(1)["data_shape"][0]
+
     try:
-        yield nexus_writer_1, nexus_writer_2
+        yield writers
 
     finally:
-        for writer in [nexus_writer_1, nexus_writer_2]:
+        for writer in writers:
             os.remove(writer.nexus_file)
             os.remove(writer.master_file)
 

--- a/tests/unit_tests/external_interaction/nexus/test_write_nexus.py
+++ b/tests/unit_tests/external_interaction/nexus/test_write_nexus.py
@@ -20,6 +20,8 @@ from hyperion.parameters.plan_specific.gridscan_internal_params import (
 that confirms that we're passing the right sorts of data to nexgen to get a sensible output.
 Note that the testing process does now write temporary files to disk."""
 
+TEST_FLUX = 1e10
+
 
 def assert_end_data_correct(nexus_writer: NexusWriter):
     for filename in [nexus_writer.nexus_file, nexus_writer.master_file]:
@@ -32,7 +34,7 @@ def assert_end_data_correct(nexus_writer: NexusWriter):
 def create_nexus_writer(parameters, writer_num):
     nexus_writer = NexusWriter(parameters, **parameters.get_nexus_info(writer_num))
     nexus_writer.beam, nexus_writer.attenuator = create_beam_and_attenuator_parameters(
-        parameters.hyperion_params.ispyb_params
+        20, TEST_FLUX, 0.5
     )
     return nexus_writer
 
@@ -135,7 +137,7 @@ def test_given_dummy_data_then_datafile_written_correctly(
                 flux := written_nexus_file["/entry/instrument/beam/total_flux"],
                 h5py.Dataset,
             )
-            assert flux[()] == 9.0
+            assert flux[()] == TEST_FLUX
             assert_contains_external_link(data_path, "data_000001", "dummy_0_000001.h5")
             assert isinstance(omega := data_path["omega"], h5py.Dataset)
             assert np.all(omega[:] == 0.0)
@@ -187,7 +189,7 @@ def test_given_dummy_data_then_datafile_written_correctly(
                 flux := written_nexus_file["/entry/instrument/beam/total_flux"],
                 h5py.Dataset,
             )
-            assert flux[()] == 9.0
+            assert flux[()] == TEST_FLUX
             assert_contains_external_link(data_path, "data_000001", "dummy_0_000001.h5")
             assert_contains_external_link(data_path, "data_000002", "dummy_0_000002.h5")
             assert isinstance(omega := data_path["omega"], h5py.Dataset)


### PR DESCRIPTION
Fixes #1173

Removes any dependency that Nexus writing has on `ispyb_params`.

Note that this does mean that the nexus file is only written when all this data comes in, which is at a different point for rotations/grids. I think if we do https://github.com/DiamondLightSource/hyperion/issues/1245 then we're pretty close to being able to have one nexus callback for both

### To test:
1. Confirm no reference to ispyb_params in nexus callbacks
2. Confirm tests are comprehensive and pass
