### PR TITLE
(#1299) Add regex filter to include only build tags in the deployment script

### DIFF
--- a/utility_scripts/deploy/deploy_hyperion.py
+++ b/utility_scripts/deploy/deploy_hyperion.py
@@ -5,11 +5,11 @@ from subprocess import PIPE, CalledProcessError, Popen
 from uuid import uuid1
 
 from git import Repo
-from packaging.version import Version
+from packaging.version import VERSION_PATTERN, Version
 
 recognised_beamlines = ["dev", "i03", "i04"]
 
-VERSION_PATTERN = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+VERSION_PATTERN_COMPILED = re.compile(VERSION_PATTERN, re.VERBOSE | re.IGNORECASE)
 
 
 class repo:
@@ -22,7 +22,7 @@ class repo:
         self.origin.fetch()
 
         self.versions = [
-            t.name for t in self.repo.tags if VERSION_PATTERN.match(t.name)
+            t.name for t in self.repo.tags if VERSION_PATTERN_COMPILED.match(t.name)
         ]
         self.versions.sort(key=Version, reverse=True)
         print(f"Found {self.name}_versions:\n{os.linesep.join(self.versions)}")

--- a/utility_scripts/deploy/deploy_hyperion.py
+++ b/utility_scripts/deploy/deploy_hyperion.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import re
 from subprocess import PIPE, CalledProcessError, Popen
 from uuid import uuid1
 
@@ -7,6 +8,8 @@ from git import Repo
 from packaging.version import Version
 
 recognised_beamlines = ["dev", "i03", "i04"]
+
+VERSION_PATTERN = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
 
 
 class repo:
@@ -18,7 +21,9 @@ class repo:
         self.origin = self.repo.remotes.origin
         self.origin.fetch()
 
-        self.versions = [t.name for t in self.repo.tags]
+        self.versions = [
+            t.name for t in self.repo.tags if VERSION_PATTERN.match(t.name)
+        ]
         self.versions.sort(key=Version, reverse=True)
         print(f"Found {self.name}_versions:\n{os.linesep.join(self.versions)}")
         self.latest_version_str = self.versions[0]


### PR DESCRIPTION
Fixes #1299

Link to dodal PR (if required): #N/A
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. deploying a release from dev workspace as per the wiki should now work even if you have other tags in your git repository

