### PR TITLE
(#1321) Update references to nexgen modules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     ispyb
     scanspec
     numpy
-    nexgen>0.8.3
+    nexgen>=0.9.1
     opentelemetry-distro
     opentelemetry-exporter-jaeger
     ophyd

--- a/src/hyperion/external_interaction/nexus/nexus_utils.py
+++ b/src/hyperion/external_interaction/nexus/nexus_utils.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import numpy as np
 from dodal.devices.detector import DetectorParams
 from nexgen.nxs_utils import Attenuator, Axis, Beam, Detector, EigerDetector, Goniometer
-from nexgen.nxs_utils.Axes import TransformationType
+from nexgen.nxs_utils.axes import TransformationType
 from numpy.typing import DTypeLike
 
 from hyperion.log import NEXUS_LOGGER

--- a/src/hyperion/external_interaction/nexus/write_nexus.py
+++ b/src/hyperion/external_interaction/nexus/write_nexus.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from dodal.utils import get_beamline_name
 from nexgen.nxs_utils import Attenuator, Beam, Detector, Goniometer, Source
-from nexgen.nxs_write.NXmxWriter import NXmxFileWriter
+from nexgen.nxs_write.nxmx_writer import NXmxFileWriter
 from numpy.typing import DTypeLike
 
 from hyperion.external_interaction.nexus.nexus_utils import (


### PR DESCRIPTION
Fixes #1321 

Merge together with creating a new Nexgen release
Note: tests are expected to fail (with `ImportError`s from nexgen) against the current release or older version of nexgen

### To test:
1. See tests pass with nexgen main
