### PR TITLE
Use new params in rotation scan plan

### DIFF
--- a/src/hyperion/device_setup_plans/manipulate_sample.py
+++ b/src/hyperion/device_setup_plans/manipulate_sample.py
@@ -61,3 +61,25 @@ def move_x_y_z(
         yield from bps.abs_set(smargon.z, z, group=group)
     if wait:
         yield from bps.wait(group)
+
+
+def move_phi_chi_omega(
+    smargon: Smargon,
+    phi: float | None = None,
+    chi: float | None = None,
+    omega: float | None = None,
+    wait=False,
+    group="move_phi_chi_omega",
+):
+    """Move the x, y, and z axes of the given smargon to the specified position. All
+    axes are optional."""
+
+    LOGGER.info(f"Moving smargon to phi, chi, omega: {(phi, chi, omega)}")
+    if phi:
+        yield from bps.abs_set(smargon.phi, phi, group=group)
+    if chi:
+        yield from bps.abs_set(smargon.chi, chi, group=group)
+    if omega:
+        yield from bps.abs_set(smargon.omega, omega, group=group)
+    if wait:
+        yield from bps.wait(group)

--- a/src/hyperion/parameters/components.py
+++ b/src/hyperion/parameters/components.py
@@ -61,7 +61,7 @@ class XyzAxis(str, Enum):
 class HyperionParameters(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-        use_enum_values = True
+        # use_enum_values = True
         extra = Extra.forbid
         json_encoders = {
             ParameterVersion: lambda pv: str(pv),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,9 +66,7 @@ from hyperion.parameters.plan_specific.gridscan_internal_params import (
 from hyperion.parameters.plan_specific.panda.panda_gridscan_internal_params import (
     PandAGridscanInternalParameters,
 )
-from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
-    RotationInternalParameters,
-)
+from hyperion.parameters.rotation import RotationScan
 
 i03.DAQ_CONFIGURATION_PATH = "tests/test_data/test_daq_configuration"
 
@@ -217,18 +215,18 @@ def test_panda_fgs_params():
 
 @pytest.fixture
 def test_rotation_params():
-    return RotationInternalParameters(
+    return RotationScan(
         **raw_params_from_file(
-            "tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json"
+            "tests/test_data/new_parameter_json_files/good_test_rotation_scan_parameters.json"
         )
     )
 
 
 @pytest.fixture
 def test_rotation_params_nomove():
-    return RotationInternalParameters(
+    return RotationScan(
         **raw_params_from_file(
-            "tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json"
+            "tests/test_data/new_parameter_json_files/good_test_rotation_scan_parameters_nomove.json"
         )
     )
 


### PR DESCRIPTION
Contributes towards #1275 

Uses the new param model throughout rotation scan plan
adds a little move chi/phi setup plan because this was expected behaviour our tests missed due to the default position being 0

### To test:
1. Run tests
