### PR TITLE
(#1324) Update python version to 3.11

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           architecture: x64
 
       - name: Checkout Hyperion
@@ -40,7 +40,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install with latest dependencies
         run: pip install -e .[dev]

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10"]
+        python: ["3.11"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pre_release_workflow.yml
+++ b/.github/workflows/pre_release_workflow.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
           architecture: x64
       - name: checkout
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 AS build
+FROM python:3.11 AS build
 ADD . /project/
 WORKDIR "/project"
 RUN pip install -e .[dev]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Left to do is:
 Development Installation
 =================
 
-This project rquires Python 3.11.
+This project supports only the most recent Python version for which our dependencies are available - currently Python 3.11.
 
 Run `./utility_scripts/dls_dev_env.sh` (This assumes you're on a DLS machine. If you are not, you should be able to just run a subset of this script)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Left to do is:
 Development Installation
 =================
 
+This project rquires Python 3.11.
+
 Run `./utility_scripts/dls_dev_env.sh` (This assumes you're on a DLS machine. If you are not, you should be able to just run a subset of this script)
 
 Note that because Hyperion makes heavy use of [Dodal](https://github.com/DiamondLightSource/dodal) this will also pull a local editable version of dodal to the parent folder of this repo.

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,12 +7,10 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 classifiers =
     Development Status :: 3 - Alpha
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.11
 packages = find:
 package_dir =
     =src

--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, List, Union
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -326,7 +326,7 @@ def run_gridscan_and_move(
 
 def flyscan_xray_centre(
     composite: FlyScanXRayCentreComposite,
-    parameters: ThreeDGridScan | GridscanInternalParameters | Any,
+    parameters: Union[ThreeDGridScan, GridscanInternalParameters, Any],
 ) -> MsgGenerator:
     """Create the plan to run the grid scan based on provided parameters.
 

--- a/src/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
-from typing import Any
+from typing import Any, Union
 
 import numpy as np
 from blueapi.core import BlueskyContext, MsgGenerator
@@ -248,7 +248,9 @@ def detect_grid_and_do_gridscan(
 
 def grid_detect_then_xray_centre(
     composite: GridDetectThenXRayCentreComposite,
-    parameters: GridScanWithEdgeDetectInternalParameters | GridScanWithEdgeDetect | Any,
+    parameters: Union[
+        GridScanWithEdgeDetectInternalParameters, GridScanWithEdgeDetect, Any
+    ],
     oav_config: str = OAV_CONFIG_JSON,
 ) -> MsgGenerator:
     """

--- a/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -255,7 +255,7 @@ def run_gridscan_and_move(
 
 def panda_flyscan_xray_centre(
     composite: FlyScanXRayCentreComposite,
-    parameters: ThreeDGridScan | PandAGridscanInternalParameters | Any,
+    parameters: Union[ThreeDGridScan, PandAGridscanInternalParameters, Any],
 ) -> MsgGenerator:
     """Create the plan to run the grid scan based on provided parameters.
 

--- a/src/hyperion/experiment_plans/pin_centre_then_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/pin_centre_then_xray_centre_plan.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Union
 
 from blueapi.core import BlueskyContext, MsgGenerator
 from dodal.devices.eiger import EigerDetector
@@ -85,9 +85,9 @@ def pin_centre_then_xray_centre_plan(
 
 def pin_tip_centre_then_xray_centre(
     composite: GridDetectThenXRayCentreComposite,
-    parameters: (
-        PinTipCentreThenXrayCentre | PinCentreThenXrayCentreInternalParameters | Any
-    ),
+    parameters: Union[
+        PinTipCentreThenXrayCentre, PinCentreThenXrayCentreInternalParameters, Any
+    ],
     oav_config_file: str = OAV_CONFIG_JSON,
 ) -> MsgGenerator:
     """Starts preparing for collection then performs the pin tip centre and xray centre"""

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
+from typing import Any, Union
 
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
@@ -253,7 +253,7 @@ def cleanup_plan(composite: RotationScanComposite, max_vel: float, **kwargs):
 
 def rotation_scan(
     composite: RotationScanComposite,
-    parameters: RotationScan | RotationInternalParameters | Any,
+    parameters: Union[RotationScan, RotationInternalParameters, Any],
 ) -> MsgGenerator:
     old_parameters = (
         parameters

--- a/utility_scripts/deploy/deploy_hyperion.py
+++ b/utility_scripts/deploy/deploy_hyperion.py
@@ -9,7 +9,9 @@ from packaging.version import VERSION_PATTERN, Version
 
 recognised_beamlines = ["dev", "i03", "i04"]
 
-VERSION_PATTERN_COMPILED = re.compile(VERSION_PATTERN, re.VERBOSE | re.IGNORECASE)
+VERSION_PATTERN_COMPILED = re.compile(
+    f"^{VERSION_PATTERN}$", re.VERBOSE | re.IGNORECASE
+)
 
 
 class repo:

--- a/utility_scripts/dls_dev_env.sh
+++ b/utility_scripts/dls_dev_env.sh
@@ -10,7 +10,7 @@ fi
 # controls_dev sets pip up to look at a local pypi server, which is incomplete
 module unload controls_dev 
 
-module load python/3.10
+module load python/3.11
 
 if [ -d "./.venv" ]
 then
@@ -35,6 +35,6 @@ fi
 pip install -e ../dodal[dev]
 
 # get dlstbx into our env
-ln -s /dls_sw/apps/dials/latest/latest/modules/dlstbx/src/dlstbx/ .venv/lib/python3.10/site-packages/dlstbx
+ln -s /dls_sw/apps/dials/latest/latest/modules/dlstbx/src/dlstbx/ .venv/lib/python3.11/site-packages/dlstbx
 
 pytest -m "not s03"


### PR DESCRIPTION
Fixes #1324

Link to dodal PR (if required): #N/A
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

Also fix a minor issue in `deploy_hyperion.py` wrt parsing of tags to versions when they aren't formatted as such

Acceptance criteria

    CI runs with only python 3.11
    the deploy script installs with 3.11
    references to older python versions (e.g. in setup.cfg are removed)
    this policy is documented in ``README`
    there is an issue for moving to 3.12 when compatible ophyd-async/p4p are available

Link to GH issue for Python 3.12 is #1329
