### PR TITLE
 Convert UDCDirectoryProvider to standard pattern

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     xarray
     doct
     databroker
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@6864607ad8cf5415fa63cafa0a8a7ff955471eeb
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@cf1ac0abf0a65090d1e8e5f2df5f7fd9396387ab
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103

--- a/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
@@ -7,7 +7,7 @@ import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 import numpy as np
 from blueapi.core import BlueskyContext, MsgGenerator
-from dodal.common import udc_directory_provider
+from dodal.beamlines.beamline_utils import get_directory_provider
 from dodal.devices.panda_fast_grid_scan import (
     set_fast_grid_scan_params as set_flyscan_params,
 )
@@ -196,9 +196,7 @@ def run_gridscan_and_move(
         time_between_x_steps_ms,
     )
 
-    udc_directory_provider.set_directory(
-        Path(parameters.hyperion_params.detector_params.directory)
-    )
+    get_directory_provider().update(directory=Path(parameters.hyperion_params.detector_params.directory))
     yield from setup_panda_for_flyscan(
         fgs_composite.panda,
         PANDA_SETUP_PATH,

--- a/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
@@ -196,7 +196,9 @@ def run_gridscan_and_move(
         time_between_x_steps_ms,
     )
 
-    get_directory_provider().update(directory=Path(parameters.hyperion_params.detector_params.directory))
+    get_directory_provider().update(
+        directory=Path(parameters.hyperion_params.detector_params.directory)
+    )
     yield from setup_panda_for_flyscan(
         fgs_composite.panda,
         PANDA_SETUP_PATH,

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -485,7 +485,7 @@ class TestFlyscanXrayCentrePlan:
         new=MagicMock(return_value=iter([])),
     )
     @patch(
-        "hyperion.experiment_plans.panda_flyscan_xray_centre_plan.get_directory_provider.update",
+        "hyperion.experiment_plans.panda_flyscan_xray_centre_plan.get_directory_provider",
         autospec=True,
     )
     def test_when_gridscan_run_panda_directory_applied(

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -485,7 +485,7 @@ class TestFlyscanXrayCentrePlan:
         new=MagicMock(return_value=iter([])),
     )
     @patch(
-        "hyperion.experiment_plans.panda_flyscan_xray_centre_plan.udc_directory_provider.set_directory",
+        "hyperion.experiment_plans.panda_flyscan_xray_centre_plan.get_directory_provider.update",
         autospec=True,
     )
     def test_when_gridscan_run_panda_directory_applied(

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -500,7 +500,7 @@ class TestFlyscanXrayCentrePlan:
             run_gridscan_and_move(fake_fgs_composite, test_panda_fgs_params)
         )
         expected_path = Path("/dls/i03/data/2023/cm33866-5/test_hyperion")
-        get_directory_provider().update.assert_called_once_with(expected_path)
+        get_directory_provider().update.assert_called_once_with(directory=expected_path)
 
     @patch(
         "hyperion.experiment_plans.panda_flyscan_xray_centre_plan.run_gridscan",

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -490,7 +490,7 @@ class TestFlyscanXrayCentrePlan:
     )
     def test_when_gridscan_run_panda_directory_applied(
         self,
-        set_directory,
+        get_directory_provider,
         RE_with_subs: tuple[RunEngine, Any],
         test_panda_fgs_params: PandAGridscanInternalParameters,
         fake_fgs_composite: FlyScanXRayCentreComposite,
@@ -500,7 +500,7 @@ class TestFlyscanXrayCentrePlan:
             run_gridscan_and_move(fake_fgs_composite, test_panda_fgs_params)
         )
         expected_path = Path("/dls/i03/data/2023/cm33866-5/test_hyperion")
-        set_directory.assert_called_once_with(expected_path)
+        get_directory_provider().update.assert_called_once_with(expected_path)
 
     @patch(
         "hyperion.experiment_plans.panda_flyscan_xray_centre_plan.run_gridscan",


### PR DESCRIPTION
Fixes #1355 

Link to dodal PR (if required): #[505](https://github.com/DiamondLightSource/dodal/pull/505)
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

This ensures that the DirectoryProvider is a singleton that will reliably be shared between all devices if e.g. copying a detector from an existing beamline. It also exposes it to the pre-processor that is being used for configuring devices per-Run.

### To test:
1. Check that PandA would write into correct directory for parameters if it wrote to a directory
