### PR TITLE
Correctly handle passed-in ISPyB experiment type (i.e. "characterization")

### DIFF
--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -16,7 +16,6 @@ from hyperion.external_interaction.callbacks.rotation.ispyb_mapping import (
 )
 from hyperion.external_interaction.ispyb.data_model import (
     DataCollectionInfo,
-    ExperimentType,
     ScanDataInfo,
 )
 from hyperion.external_interaction.ispyb.ispyb_store import (
@@ -24,6 +23,7 @@ from hyperion.external_interaction.ispyb.ispyb_store import (
     StoreInIspyb,
 )
 from hyperion.log import ISPYB_LOGGER, set_dcgid_tag
+from hyperion.parameters.components import IspybExperimentType
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
     RotationInternalParameters,
@@ -92,10 +92,12 @@ class RotationISPyBCallback(BaseISPyBCallback):
             if experiment_type:
                 self.ispyb = StoreInIspyb(
                     self.ispyb_config,
-                    ExperimentType(experiment_type),
+                    IspybExperimentType(experiment_type),
                 )
             else:
-                self.ispyb = StoreInIspyb(self.ispyb_config, ExperimentType.ROTATION)
+                self.ispyb = StoreInIspyb(
+                    self.ispyb_config, IspybExperimentType.ROTATION
+                )
             ISPYB_LOGGER.info("Beginning ispyb deposition")
             data_collection_group_info = populate_data_collection_group(
                 self.ispyb.experiment_type,

--- a/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -23,7 +23,6 @@ from hyperion.external_interaction.callbacks.xray_centre.ispyb_mapping import (
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
 from hyperion.external_interaction.ispyb.data_model import (
     DataCollectionInfo,
-    ExperimentType,
     ScanDataInfo,
 )
 from hyperion.external_interaction.ispyb.ispyb_store import (
@@ -31,6 +30,7 @@ from hyperion.external_interaction.ispyb.ispyb_store import (
     StoreInIspyb,
 )
 from hyperion.log import ISPYB_LOGGER, set_dcgid_tag
+from hyperion.parameters.components import IspybExperimentType
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,
@@ -93,7 +93,9 @@ class GridscanISPyBCallback(BaseISPyBCallback):
             )
             json_params = doc.get("hyperion_internal_parameters")
             self.params = GridscanInternalParameters.from_json(json_params)
-            self.ispyb = StoreInIspyb(self.ispyb_config, ExperimentType.GRIDSCAN_3D)
+            self.ispyb = StoreInIspyb(
+                self.ispyb_config, IspybExperimentType.GRIDSCAN_3D
+            )
             data_collection_group_info = populate_data_collection_group(
                 self.ispyb.experiment_type,
                 self.params.hyperion_params.detector_params,

--- a/src/hyperion/external_interaction/ispyb/data_model.py
+++ b/src/hyperion/external_interaction/ispyb/data_model.py
@@ -1,53 +1,7 @@
 from dataclasses import asdict, dataclass
-from enum import Enum
 from typing import Optional
 
 from hyperion.external_interaction.ispyb.ispyb_dataclass import Orientation
-
-
-class ExperimentType(Enum):
-    # Enum values from ispyb column data type
-    SAD = "SAD"  # at or slightly above the peak
-    SAD_INVERSE_BEAM = "SAD - Inverse Beam"
-    OSC = "OSC"  # "native" (in the absence of a heavy atom)
-    COLLECT_MULTIWEDGE = (
-        "Collect - Multiwedge"  # "poorly determined" ~ EDNA complex strategy???
-    )
-    MAD = "MAD"
-    HELICAL = "Helical"
-    MULTI_POSITIONAL = "Multi-positional"
-    MESH = "Mesh"
-    BURN = "Burn"
-    MAD_INVERSE_BEAM = "MAD - Inverse Beam"
-    CHARACTERIZATION = "Characterization"
-    DEHYDRATION = "Dehydration"
-    TOMO = "tomo"
-    EXPERIMENT = "experiment"
-    EM = "EM"
-    PDF = "PDF"
-    PDF_BRAGG = "PDF+Bragg"
-    BRAGG = "Bragg"
-    SINGLE_PARTICLE = "single particle"
-    SERIAL_FIXED = "Serial Fixed"
-    SERIAL_JET = "Serial Jet"
-    STANDARD = "Standard"  # Routine structure determination experiment
-    TIME_RESOLVED = "Time Resolved"  # Investigate the change of a system over time
-    DLS_ANVIL_HP = "Diamond Anvil High Pressure"  # HP sample environment pressure cell
-    CUSTOM = "Custom"  # Special or non-standard data collection
-    XRF_MAP = "XRF map"
-    ENERGY_SCAN = "Energy scan"
-    XRF_SPECTRUM = "XRF spectrum"
-    XRF_MAP_XAS = "XRF map xas"
-    MESH_3D = "Mesh3D"
-    SCREENING = "Screening"
-    STILL = "Still"
-    SSX_CHIP = "SSX-Chip"
-    SSX_JET = "SSX-Jet"
-
-    # Aliases for historic hyperion experiment type mapping
-    ROTATION = "SAD"
-    GRIDSCAN_2D = "mesh"
-    GRIDSCAN_3D = "Mesh3D"
 
 
 @dataclass()

--- a/src/hyperion/external_interaction/ispyb/ispyb_store.py
+++ b/src/hyperion/external_interaction/ispyb/ispyb_store.py
@@ -15,7 +15,6 @@ from hyperion.external_interaction.ispyb.data_model import (
     DataCollectionGridInfo,
     DataCollectionGroupInfo,
     DataCollectionInfo,
-    ExperimentType,
     ScanDataInfo,
 )
 from hyperion.external_interaction.ispyb.ispyb_utils import (
@@ -23,6 +22,7 @@ from hyperion.external_interaction.ispyb.ispyb_utils import (
     get_session_id_from_visit,
 )
 from hyperion.log import ISPYB_LOGGER
+from hyperion.parameters.components import IspybExperimentType
 from hyperion.tracing import TRACER
 
 if TYPE_CHECKING:
@@ -39,7 +39,7 @@ class IspybIds(BaseModel):
 
 
 class StoreInIspyb(ABC):
-    def __init__(self, ispyb_config: str, experiment_type: ExperimentType) -> None:
+    def __init__(self, ispyb_config: str, experiment_type: IspybExperimentType) -> None:
         self.ISPYB_CONFIG_PATH: str = ispyb_config
         self._data_collection_group_id: int | None
         self._experiment_type = experiment_type

--- a/src/hyperion/parameters/components.py
+++ b/src/hyperion/parameters/components.py
@@ -235,7 +235,7 @@ class OptionalGonioAngleStarts(BaseModel):
 
 
 class TemporaryIspybExtras(BaseModel):
-    # for while we still need ISpyB params_to be removed in #1277 and/or #43
+    # for while we still need ISpyB params - to be removed in #1277 and/or #43
     class Config:
         arbitrary_types_allowed = True
         extra = Extra.forbid

--- a/src/hyperion/parameters/components.py
+++ b/src/hyperion/parameters/components.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Sequence, SupportsInt, TypeVar
 
@@ -45,17 +45,62 @@ class ParameterVersion(Version):
 PARAMETER_VERSION = ParameterVersion.parse("5.0.0")
 
 
-class RotationAxis(str, Enum):
+class RotationAxis(StrEnum):
     OMEGA = "omega"
     PHI = "phi"
     CHI = "chi"
     KAPPA = "kappa"
 
 
-class XyzAxis(str, Enum):
+class XyzAxis(StrEnum):
     X = "sam_x"
     Y = "sam_y"
     Z = "sam_z"
+
+
+class IspybExperimentType(StrEnum):
+    # Enum values from ispyb column data type
+    SAD = "SAD"  # at or slightly above the peak
+    SAD_INVERSE_BEAM = "SAD - Inverse Beam"
+    OSC = "OSC"  # "native" (in the absence of a heavy atom)
+    COLLECT_MULTIWEDGE = (
+        "Collect - Multiwedge"  # "poorly determined" ~ EDNA complex strategy???
+    )
+    MAD = "MAD"
+    HELICAL = "Helical"
+    MULTI_POSITIONAL = "Multi-positional"
+    MESH = "Mesh"
+    BURN = "Burn"
+    MAD_INVERSE_BEAM = "MAD - Inverse Beam"
+    CHARACTERIZATION = "Characterization"
+    DEHYDRATION = "Dehydration"
+    TOMO = "tomo"
+    EXPERIMENT = "experiment"
+    EM = "EM"
+    PDF = "PDF"
+    PDF_BRAGG = "PDF+Bragg"
+    BRAGG = "Bragg"
+    SINGLE_PARTICLE = "single particle"
+    SERIAL_FIXED = "Serial Fixed"
+    SERIAL_JET = "Serial Jet"
+    STANDARD = "Standard"  # Routine structure determination experiment
+    TIME_RESOLVED = "Time Resolved"  # Investigate the change of a system over time
+    DLS_ANVIL_HP = "Diamond Anvil High Pressure"  # HP sample environment pressure cell
+    CUSTOM = "Custom"  # Special or non-standard data collection
+    XRF_MAP = "XRF map"
+    ENERGY_SCAN = "Energy scan"
+    XRF_SPECTRUM = "XRF spectrum"
+    XRF_MAP_XAS = "XRF map xas"
+    MESH_3D = "Mesh3D"
+    SCREENING = "Screening"
+    STILL = "Still"
+    SSX_CHIP = "SSX-Chip"
+    SSX_JET = "SSX-Jet"
+
+    # Aliases for historic hyperion experiment type mapping
+    ROTATION = "SAD"
+    GRIDSCAN_2D = "mesh"
+    GRIDSCAN_3D = "Mesh3D"
 
 
 class HyperionParameters(BaseModel):
@@ -104,6 +149,7 @@ class DiffractionExperiment(HyperionParameters):
     detector_distance_mm: float | None = Field(default=None, gt=0)
     demand_energy_ev: float | None = Field(default=None, gt=0)
     run_number: int | None = Field(default=None, ge=0)
+    ispyb_experiment_type: IspybExperimentType | None = None
     storage_directory: str
 
     @property
@@ -189,7 +235,7 @@ class OptionalGonioAngleStarts(BaseModel):
 
 
 class TemporaryIspybExtras(BaseModel):
-    # for while we still need ISpyB params - to be removed in #1277 and/or #43
+    # for while we still need ISpyB params_to be removed in #1277 and/or #43
     class Config:
         arbitrary_types_allowed = True
         extra = Extra.forbid
@@ -204,4 +250,3 @@ class TemporaryIspybExtras(BaseModel):
     xtal_snapshots_omega_start: list[str] | None = None
     xtal_snapshots_omega_end: list[str] | None = None
     xtal_snapshots: list[str] | None = None
-    ispyb_experiment_type: str | None = None

--- a/src/hyperion/parameters/gridscan.py
+++ b/src/hyperion/parameters/gridscan.py
@@ -77,7 +77,7 @@ class GridCommon(
             xtal_snapshots_omega_start=self.ispyb_extras.xtal_snapshots_omega_start
             or [],
             xtal_snapshots_omega_end=self.ispyb_extras.xtal_snapshots_omega_end or [],
-            ispyb_experiment_type=self.ispyb_extras.ispyb_experiment_type,
+            ispyb_experiment_type=self.ispyb_experiment_type,
         )
 
     @property

--- a/src/hyperion/parameters/rotation.py
+++ b/src/hyperion/parameters/rotation.py
@@ -18,6 +18,7 @@ from scanspec.specs import Line
 from hyperion.external_interaction.ispyb.ispyb_dataclass import RotationIspybParams
 from hyperion.parameters.components import (
     DiffractionExperiment,
+    IspybExperimentType,
     OptionalGonioAngleStarts,
     OptionalXyzStarts,
     RotationAxis,
@@ -46,6 +47,9 @@ class RotationScan(
     scan_width_deg: float = Field(default=360, gt=0)
     rotation_increment_deg: float = Field(default=0.1, gt=0)
     rotation_direction: RotationDirection = Field(default=RotationDirection.NEGATIVE)
+    ispyb_experiment_type: IspybExperimentType = Field(
+        default=IspybExperimentType.ROTATION
+    )
     transmission_frac: float
     ispyb_extras: TemporaryIspybExtras
 
@@ -93,7 +97,7 @@ class RotationScan(
             undulator_gap=self.ispyb_extras.undulator_gap,
             xtal_snapshots_omega_start=self.ispyb_extras.xtal_snapshots_omega_start,
             xtal_snapshots_omega_end=self.ispyb_extras.xtal_snapshots_omega_end,
-            ispyb_experiment_type="SAD",
+            ispyb_experiment_type=self.ispyb_experiment_type,
         )
 
     @property

--- a/tests/system_tests/external_interaction/conftest.py
+++ b/tests/system_tests/external_interaction/conftest.py
@@ -9,8 +9,8 @@ from ispyb.sqlalchemy import DataCollection, DataCollectionGroup, GridInfo, Posi
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from hyperion.external_interaction.ispyb.data_model import ExperimentType
 from hyperion.external_interaction.ispyb.ispyb_store import StoreInIspyb
+from hyperion.parameters.components import IspybExperimentType
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,
@@ -159,12 +159,16 @@ def dummy_params():
 
 @pytest.fixture
 def dummy_ispyb(dummy_params) -> StoreInIspyb:
-    return StoreInIspyb(CONST.SIM.DEV_ISPYB_DATABASE_CFG, ExperimentType.GRIDSCAN_2D)
+    return StoreInIspyb(
+        CONST.SIM.DEV_ISPYB_DATABASE_CFG, IspybExperimentType.GRIDSCAN_2D
+    )
 
 
 @pytest.fixture
 def dummy_ispyb_3d(dummy_params) -> StoreInIspyb:
-    return StoreInIspyb(CONST.SIM.DEV_ISPYB_DATABASE_CFG, ExperimentType.GRIDSCAN_3D)
+    return StoreInIspyb(
+        CONST.SIM.DEV_ISPYB_DATABASE_CFG, IspybExperimentType.GRIDSCAN_3D
+    )
 
 
 @pytest.fixture

--- a/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
@@ -45,7 +45,6 @@ from hyperion.external_interaction.callbacks.xray_centre.ispyb_mapping import (
 )
 from hyperion.external_interaction.ispyb.data_model import (
     DataCollectionGridInfo,
-    ExperimentType,
     ScanDataInfo,
 )
 from hyperion.external_interaction.ispyb.ispyb_dataclass import Orientation
@@ -53,6 +52,7 @@ from hyperion.external_interaction.ispyb.ispyb_store import (
     IspybIds,
     StoreInIspyb,
 )
+from hyperion.parameters.components import IspybExperimentType
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.gridscan import GridScanWithEdgeDetect
 from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
@@ -205,7 +205,7 @@ GRID_INFO_COLUMN_MAP = {
 @pytest.fixture
 def dummy_data_collection_group_info(dummy_params):
     return populate_data_collection_group(
-        ExperimentType.GRIDSCAN_2D.value,
+        IspybExperimentType.GRIDSCAN_2D.value,
         dummy_params.hyperion_params.detector_params,
         dummy_params.hyperion_params.ispyb_params,
     )
@@ -491,7 +491,7 @@ def test_ispyb_deposition_comment_correct_for_3D_on_failure(
     scan_data_infos = generate_scan_data_infos(
         dummy_params,
         dummy_scan_data_info_for_begin,
-        ExperimentType.GRIDSCAN_3D,
+        IspybExperimentType.GRIDSCAN_3D,
         ispyb_ids,
     )
     ispyb_ids = dummy_ispyb_3d.update_deposition(ispyb_ids, scan_data_infos)
@@ -512,10 +512,10 @@ def test_ispyb_deposition_comment_correct_for_3D_on_failure(
 @pytest.mark.parametrize(
     "experiment_type, exp_num_of_grids, success",
     [
-        (ExperimentType.GRIDSCAN_2D, 1, False),
-        (ExperimentType.GRIDSCAN_2D, 1, True),
-        (ExperimentType.GRIDSCAN_3D, 2, False),
-        (ExperimentType.GRIDSCAN_3D, 2, True),
+        (IspybExperimentType.GRIDSCAN_2D, 1, False),
+        (IspybExperimentType.GRIDSCAN_2D, 1, True),
+        (IspybExperimentType.GRIDSCAN_3D, 2, False),
+        (IspybExperimentType.GRIDSCAN_3D, 2, True),
     ],
 )
 def test_can_store_2D_ispyb_data_correctly_when_in_error(
@@ -573,14 +573,14 @@ def test_can_store_2D_ispyb_data_correctly_when_in_error(
 def generate_scan_data_infos(
     dummy_params,
     dummy_scan_data_info_for_begin: ScanDataInfo,
-    experiment_type: ExperimentType,
+    experiment_type: IspybExperimentType,
     ispyb_ids: IspybIds,
 ) -> Sequence[ScanDataInfo]:
     xy_scan_data_info = scan_xy_data_info_for_update(
         ispyb_ids.data_collection_group_id, dummy_params, dummy_scan_data_info_for_begin
     )
     xy_scan_data_info.data_collection_id = ispyb_ids.data_collection_ids[0]
-    if experiment_type == ExperimentType.GRIDSCAN_3D:
+    if experiment_type == IspybExperimentType.GRIDSCAN_3D:
         scan_data_infos = scan_data_infos_for_update_3d(
             ispyb_ids, xy_scan_data_info, dummy_params
         )

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -32,11 +32,14 @@ from hyperion.external_interaction.callbacks.rotation.nexus_callback import (
     RotationNexusFileCallback,
 )
 from hyperion.external_interaction.exceptions import ISPyBDepositionNotMade
-from hyperion.external_interaction.ispyb.data_model import ExperimentType, ScanDataInfo
+from hyperion.external_interaction.ispyb.data_model import (
+    ScanDataInfo,
+)
 from hyperion.external_interaction.ispyb.ispyb_store import (
     IspybIds,
     StoreInIspyb,
 )
+from hyperion.parameters.components import IspybExperimentType
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
     RotationInternalParameters,
@@ -383,7 +386,7 @@ def test_ispyb_specifies_experiment_type_if_supplied(
 
     RE(fake_rotation_scan(params, [ispyb_cb]))
 
-    assert rotation_ispyb.call_args.args[1] == ExperimentType.CHARACTERIZATION
+    assert rotation_ispyb.call_args.args[1] == IspybExperimentType.CHARACTERIZATION
 
 
 n_images_store_id = [

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -375,9 +375,19 @@ def test_ispyb_specifies_experiment_type_if_supplied(
     RE: RunEngine,
     params: RotationInternalParameters,
 ):
+    raw_params = raw_params_from_file(
+        "tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json"
+    )
+    raw_params["hyperion_params"]["ispyb_params"][
+        "ispyb_experiment_type"
+    ] = "Characterization"
+    params = RotationInternalParameters(**raw_params)
+
     ispyb_cb = RotationISPyBCallback()
     ispyb_cb.active = True
-    params.hyperion_params.ispyb_params.ispyb_experiment_type = "Characterization"
+    assert (
+        params.hyperion_params.ispyb_params.ispyb_experiment_type == "Characterization"
+    )
     rotation_ispyb.return_value.begin_deposition.return_value = IspybIds(
         data_collection_group_id=23, data_collection_ids=(45,)
     )

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -44,6 +44,7 @@ from hyperion.parameters.constants import CONST
 from hyperion.parameters.plan_specific.rotation_scan_internal_params import (
     RotationInternalParameters,
 )
+from hyperion.parameters.rotation import RotationScan
 
 from ....conftest import raw_params_from_file
 
@@ -373,7 +374,6 @@ def test_ispyb_reuses_dcgid_on_same_sampleID(
 def test_ispyb_specifies_experiment_type_if_supplied(
     rotation_ispyb: MagicMock,
     RE: RunEngine,
-    params: RotationInternalParameters,
 ):
     raw_params = raw_params_from_file(
         "tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json"
@@ -382,6 +382,37 @@ def test_ispyb_specifies_experiment_type_if_supplied(
         "ispyb_experiment_type"
     ] = "Characterization"
     params = RotationInternalParameters(**raw_params)
+
+    ispyb_cb = RotationISPyBCallback()
+    ispyb_cb.active = True
+    assert (
+        params.hyperion_params.ispyb_params.ispyb_experiment_type == "Characterization"
+    )
+    rotation_ispyb.return_value.begin_deposition.return_value = IspybIds(
+        data_collection_group_id=23, data_collection_ids=(45,)
+    )
+
+    params.hyperion_params.ispyb_params.sample_id = "abc"
+
+    RE(fake_rotation_scan(params, [ispyb_cb]))
+
+    assert rotation_ispyb.call_args.args[1] == IspybExperimentType.CHARACTERIZATION
+
+
+@patch(
+    "hyperion.external_interaction.callbacks.rotation.ispyb_callback.StoreInIspyb",
+    autospec=True,
+)
+def test_new_params_ispyb_specifies_experiment_type_if_supplied(
+    rotation_ispyb: MagicMock,
+    RE: RunEngine,
+):
+    raw_params = raw_params_from_file(
+        "tests/test_data/new_parameter_json_files/good_test_rotation_scan_parameters_nomove.json"
+    )
+    raw_params["ispyb_experiment_type"] = "Characterization"
+    new_params = RotationScan(**raw_params)
+    params = new_params.old_parameters()
 
     ispyb_cb = RotationISPyBCallback()
     ispyb_cb.active = True

--- a/tests/unit_tests/external_interaction/ispyb/conftest.py
+++ b/tests/unit_tests/external_interaction/ispyb/conftest.py
@@ -5,11 +5,11 @@ import pytest
 from hyperion.external_interaction.ispyb.data_model import (
     DataCollectionGridInfo,
     DataCollectionPositionInfo,
-    ExperimentType,
     ScanDataInfo,
 )
 from hyperion.external_interaction.ispyb.ispyb_dataclass import Orientation
 from hyperion.external_interaction.ispyb.ispyb_store import StoreInIspyb
+from hyperion.parameters.components import IspybExperimentType
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,
@@ -33,19 +33,21 @@ def dummy_params():
 
 @pytest.fixture
 def dummy_3d_gridscan_ispyb():
-    store_in_ispyb_3d = StoreInIspyb(CONST.SIM.ISPYB_CONFIG, ExperimentType.GRIDSCAN_3D)
+    store_in_ispyb_3d = StoreInIspyb(
+        CONST.SIM.ISPYB_CONFIG, IspybExperimentType.GRIDSCAN_3D
+    )
     return store_in_ispyb_3d
 
 
 @pytest.fixture
 def dummy_rotation_ispyb(dummy_rotation_params):
-    store_in_ispyb = StoreInIspyb(CONST.SIM.ISPYB_CONFIG, ExperimentType.ROTATION)
+    store_in_ispyb = StoreInIspyb(CONST.SIM.ISPYB_CONFIG, IspybExperimentType.ROTATION)
     return store_in_ispyb
 
 
 @pytest.fixture
 def dummy_2d_gridscan_ispyb():
-    return StoreInIspyb(CONST.SIM.ISPYB_CONFIG, ExperimentType.GRIDSCAN_2D)
+    return StoreInIspyb(CONST.SIM.ISPYB_CONFIG, IspybExperimentType.GRIDSCAN_2D)
 
 
 @pytest.fixture

--- a/tests/unit_tests/external_interaction/ispyb/test_rotation_ispyb_store.py
+++ b/tests/unit_tests/external_interaction/ispyb/test_rotation_ispyb_store.py
@@ -6,13 +6,13 @@ from hyperion.external_interaction.ispyb.data_model import (
     DataCollectionGroupInfo,
     DataCollectionInfo,
     DataCollectionPositionInfo,
-    ExperimentType,
     ScanDataInfo,
 )
 from hyperion.external_interaction.ispyb.ispyb_store import (
     IspybIds,
     StoreInIspyb,
 )
+from hyperion.parameters.components import IspybExperimentType
 from hyperion.parameters.constants import CONST
 
 from ..conftest import (
@@ -181,7 +181,7 @@ def scan_data_info_for_update(scan_data_info_for_begin):
 @pytest.fixture
 def dummy_rotation_ispyb_with_experiment_type():
     store_in_ispyb = StoreInIspyb(
-        CONST.SIM.ISPYB_CONFIG, ExperimentType.CHARACTERIZATION
+        CONST.SIM.ISPYB_CONFIG, IspybExperimentType.CHARACTERIZATION
     )
     return store_in_ispyb
 
@@ -236,7 +236,9 @@ def test_begin_deposition_with_group_id_updates_but_doesnt_insert(
     dummy_rotation_data_collection_group_info,
     scan_data_info_for_begin,
 ):
-    dummy_rotation_ispyb = StoreInIspyb(CONST.SIM.ISPYB_CONFIG, ExperimentType.ROTATION)
+    dummy_rotation_ispyb = StoreInIspyb(
+        CONST.SIM.ISPYB_CONFIG, IspybExperimentType.ROTATION
+    )
     scan_data_info_for_begin.data_collection_info.parent_id = (
         TEST_DATA_COLLECTION_GROUP_ID
     )
@@ -367,7 +369,9 @@ def test_update_deposition_with_group_id_updates(
     scan_data_info_for_begin,
     scan_data_info_for_update,
 ):
-    dummy_rotation_ispyb = StoreInIspyb(CONST.SIM.ISPYB_CONFIG, ExperimentType.ROTATION)
+    dummy_rotation_ispyb = StoreInIspyb(
+        CONST.SIM.ISPYB_CONFIG, IspybExperimentType.ROTATION
+    )
     scan_data_info_for_begin.data_collection_info.parent_id = (
         TEST_DATA_COLLECTION_GROUP_ID
     )
@@ -492,7 +496,7 @@ def test_store_rotation_scan_uses_supplied_dcgid(
     mock_ispyb_conn.return_value.mx_acquisition.upsert_data_collection_group.return_value = (
         dcgid
     )
-    store_in_ispyb = StoreInIspyb(CONST.SIM.ISPYB_CONFIG, ExperimentType.ROTATION)
+    store_in_ispyb = StoreInIspyb(CONST.SIM.ISPYB_CONFIG, IspybExperimentType.ROTATION)
     scan_data_info_for_begin.data_collection_info.parent_id = dcgid
     ispyb_ids = store_in_ispyb.begin_deposition(
         dummy_rotation_data_collection_group_info, [scan_data_info_for_begin]


### PR DESCRIPTION
Fixes #1360 
Ensures ispyb experiment type is correctly passed along from parameters

### To test:
1. Confirm updated test now checks the right thing
