### PR TITLE
Make deploy script create venv while SSH'd into control machine

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq
-    paramiko
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
     pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103
+    paramiko
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@890027c1bcd95f8fe35576630e320b97b7959006
     pydantic<2.0 # See https://github.com/DiamondLightSource/hyperion/issues/774
     scipy
-    pyzmq<25 # See https://github.com/DiamondLightSource/hyperion/issues/1103
+    pyzmq
     paramiko
 
 [options.entry_points]

--- a/utility_scripts/deploy/create_venv.py
+++ b/utility_scripts/deploy/create_venv.py
@@ -1,0 +1,18 @@
+import sys
+from subprocess import PIPE, CalledProcessError, Popen
+
+
+def setup_venv(path_to_create_venv_script):
+    with Popen(
+        path_to_create_venv_script, stdout=PIPE, bufsize=1, universal_newlines=True
+    ) as p:
+        if p.stdout is not None:
+            for line in p.stdout:
+                print(line, end="")
+    if p.returncode != 0:
+        raise CalledProcessError(p.returncode, p.args)
+
+
+if __name__ == "__main__":
+    path_to_create_venv_script = sys.argv[1]
+    setup_venv(path_to_create_venv_script)

--- a/utility_scripts/deploy/create_venv.py
+++ b/utility_scripts/deploy/create_venv.py
@@ -19,6 +19,7 @@ def setup_venv(path_to_create_venv_script, deployment_directory):
 
 
 if __name__ == "__main__":
+    # This should only be entered from the control machine
     path_to_create_venv_script = sys.argv[1]
     deployment_directory = sys.argv[2]
     setup_venv(path_to_create_venv_script, deployment_directory)

--- a/utility_scripts/deploy/create_venv.py
+++ b/utility_scripts/deploy/create_venv.py
@@ -1,8 +1,13 @@
+import os
 import sys
 from subprocess import PIPE, CalledProcessError, Popen
 
 
-def setup_venv(path_to_create_venv_script):
+def setup_venv(path_to_create_venv_script, deployment_directory):
+    # Set up environment and run /dls_dev_env.sh...
+    os.chdir(deployment_directory)
+    print(f"Setting up environment in {deployment_directory}")
+
     with Popen(
         path_to_create_venv_script, stdout=PIPE, bufsize=1, universal_newlines=True
     ) as p:
@@ -15,4 +20,5 @@ def setup_venv(path_to_create_venv_script):
 
 if __name__ == "__main__":
     path_to_create_venv_script = sys.argv[1]
-    setup_venv(path_to_create_venv_script)
+    deployment_directory = sys.argv[2]
+    setup_venv(path_to_create_venv_script, deployment_directory)

--- a/utility_scripts/deploy/deploy_hyperion.py
+++ b/utility_scripts/deploy/deploy_hyperion.py
@@ -82,9 +82,10 @@ def get_hyperion_release_dir_from_args() -> str:
 
 def create_environment_from_control_machine():
     ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(
-        paramiko.AutoAddPolicy()
-    )  # This adds i03-control to your client's known hosts.
+
+    # This adds i03-control to your client's known hosts.
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
     username = input(
         "Setting up the venv requires SSH'ing to i03-control.\n Enter FedID:"
     )
@@ -96,9 +97,10 @@ def create_environment_from_control_machine():
             "i03-control.diamond.ac.uk", username=username, password=password
         )
         print("Succesfully connected to i03-control")
+
         # Call python script on i03-control to create the environment
         stdin, stdout, stderr = ssh_client.exec_command(
-            f"python3 {create_venv_location} {env_script}"
+            f"python3 {create_venv_location} {env_script} {hyperion_repo.deploy_location}"
         )
         stdout = stdout.readlines()
         for line in stdout:
@@ -168,7 +170,7 @@ if __name__ == "__main__":
         if release_area != DEV_DEPLOY_LOCATION:
             create_environment_from_control_machine()
         else:
-            setup_venv(create_venv_location)
+            setup_venv(create_venv_location, hyperion_repo.deploy_location)
 
     def create_symlink_by_tmp_and_rename(dirname, target, linkname):
         tmp_name = str(uuid1())

--- a/utility_scripts/deploy/deploy_hyperion.py
+++ b/utility_scripts/deploy/deploy_hyperion.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
             hyperion_repo.deploy_location, "utility_scripts/dls_dev_env.sh"
         )
         create_venv_location = os.path.join(
-            env_script, "utility_scripts/deploy/create_venv.py"
+            hyperion_repo.deploy_location, "utility_scripts/deploy/create_venv.py"
         )
 
         # SSH into control machine if not in dev mode

--- a/utility_scripts/deploy/test_deploy.py
+++ b/utility_scripts/deploy/test_deploy.py
@@ -1,0 +1,11 @@
+import subprocess
+
+cmd = "ssh qqh35939@i03-control"
+process = subprocess.Popen(
+    cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+)
+stdout, stderr = process.communicate()
+if process.returncode != 0:
+    print(f"Error occurred: {stderr.decode()}")
+else:
+    print(f"Output: {stdout.decode()}")


### PR DESCRIPTION
Fixes #1103 

Now uses `subprocess` to SSH, so that it only asks for the password if it needs it

### To test:
1. Confirm deploy script in dev mode still works as expected, using `python deploy_hyperion.py "dev"` (NOTE: this won't actually work until we make a release with this change merged in, since the script will search the latest release for the file created in this PR)
2. We don't have unit tests for the deploy script, so test live on beamline for next deployment

