### PR TITLE
Enhancements to build_imginfo.sh and run_imginfo.sh to enable building of the debug dockerfile and convenient launching

### DIFF
--- a/utility_scripts/build_imginfo.sh
+++ b/utility_scripts/build_imginfo.sh
@@ -5,6 +5,7 @@ function help {
       Create and build imginfo in the specified directory
 Options:
     -p use podman instead of docker
+    -d build debug imginfo
 `basename $0` --help|-h
       This help
 END
@@ -16,23 +17,40 @@ if [ -z "$1" ]; then
 fi
 
 DOCKER=docker
-case $1 in
-  --help|-h)
-    help
-    ;;
-  -p)
-    DOCKER=podman
-    shift
-    ;;
-  *)
+while [ -n "$1" ] ; do
+	case $1 in
+	  --help|-h)
+	    help
+	    ;;
+	  -d)
+	    DOCKERFILE=Dockerfile-imginfo-debug
+	    shift
+	    ;;
+	  -p)
+	    DOCKER=podman
+	    shift
+	    ;;
+	  *)
+	    break
+	    ;;
+	esac
+done
+if [ -z "$1" ]; then
+	echo "workspace not specified"
+	exit 1
+fi
 
-esac
 WORKDIR=$1
 IMGINFO_TAG=9810b92
 IMGINFO_GITHUB=git@github.com:githubgphl/imginfo.git
 if [ -d ${WORKDIR} ]; then
-        rm -rf ${WORKDIR}
+        rm -r ${WORKDIR}
 fi
 git clone ${IMGINFO_GITHUB} ${WORKDIR}
 git checkout ${IMGINFO_TAG}
-${DOCKER} build ${WORKDIR} --file ${WORKDIR}/Dockerfile --tag imginfo
+if [ -z "$DOCKERFILE" ]; then
+	DOCKERFILE=${WORKDIR}/Dockerfile
+else
+	DOCKERFILE=${WORKDIR}/${DOCKERFILE}
+fi
+${DOCKER} build ${WORKDIR} --file ${DOCKERFILE} --tag imginfo

--- a/utility_scripts/run_imginfo.sh
+++ b/utility_scripts/run_imginfo.sh
@@ -2,8 +2,10 @@
 function help {
     cat <<END
 Wrapper for imginfo
-`basename $0` <master.h5>
+`basename $0` [-s] <master.h5>
       Run imginfo against the specified master file
+Options:
+	-s	Start an interactive shell instead of executing imginfo
 
 Environment:
   DOCKER   set to 'podman' to use podman otherwise docker is the default
@@ -22,6 +24,20 @@ if [ -z "$DOCKER" ]; then
   DOCKER=docker
 fi
 
+while [ -n "$1" ] ; do
+	case $1 in
+	  --help|-h)
+	    help
+	    ;;
+	  -s)
+	    SHELL_MODE=1
+	    shift;
+	    ;;
+	  *)
+	    break
+	    ;;
+	esac
+done
 IMAGE_NAME=imginfo:latest
 
 if ! ${DOCKER} image inspect ${IMAGE_NAME} > /dev/null; then
@@ -32,4 +48,8 @@ fi
 MASTER_FILE=`readlink -f $1`
 PARENT_DIR=`dirname $MASTER_FILE`
 MASTER_FILENAME=`basename $MASTER_FILE`
-${DOCKER} run -v ${PARENT_DIR}:/data/ ${IMAGE_NAME} ./imginfo /data/${MASTER_FILENAME}
+if [ -n "$SHELL_MODE" ]; then
+	${DOCKER} run -t -i -v ${PARENT_DIR}:/data/:z ${IMAGE_NAME} /bin/bash
+else
+	${DOCKER} run -v ${PARENT_DIR}:/data/ ${IMAGE_NAME} ./imginfo /data/${MASTER_FILENAME}
+fi


### PR DESCRIPTION
These changes to the utility scripts assist in the building of the debug version of `imginfo` in the docker container image and launching of the built image in interactive mode for debugging.

Fixes #N/A

Link to imginfo PR (if required): githubgphl/imginfo#4
