### PR TITLE
1307 remove detector parameter from hyperion request parameters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a3
     blueapi >= 0.4.3-rc1
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@ce2a48780b979fb585214092741b76c449b05452
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
 
 [options.entry_points]
 console_scripts =

--- a/src/hyperion/parameters/components.py
+++ b/src/hyperion/parameters/components.py
@@ -153,7 +153,6 @@ class DiffractionExperiment(HyperionParameters):
         default=CONST.PARAM.DETECTOR.BEAM_XY_LUT_PATH
     )
     zocalo_environment: str = Field(default=CONST.ZOCALO_ENV)
-    detector: str = Field(default=CONST.I03.DETECTOR)
     trigger_mode: TriggerMode = Field(default=TriggerMode.FREE_RUN)
     detector_distance_mm: float | None = Field(default=None, gt=0)
     demand_energy_ev: float | None = Field(default=None, gt=0)

--- a/src/hyperion/parameters/constants.py
+++ b/src/hyperion/parameters/constants.py
@@ -1,6 +1,7 @@
 import os
 from enum import Enum
 
+from dodal.devices.detector import EIGER2_X_16M_SIZE
 from pydantic.dataclasses import dataclass
 
 TEST_MODE = os.environ.get("HYPERION_TEST_MODE")
@@ -89,7 +90,7 @@ _live_oav_file = "/dls_sw/i03/software/daq_configuration/json/OAVCentring_hyperi
 class I03Constants:
     BASE_DATA_DIR = "/tmp/dls/i03/data/" if TEST_MODE else "/dls/i03/data/"
     BEAMLINE = "BL03S" if TEST_MODE else "BL03I"
-    DETECTOR = "EIGER2_X_16M"
+    DETECTOR = EIGER2_X_16M_SIZE
     INSERTION_PREFIX = "SR03S" if TEST_MODE else "SR03I"
     OAV_CENTRING_FILE = _test_oav_file if TEST_MODE else _live_oav_file
     SHUTTER_TIME_S = 0.06

--- a/src/hyperion/parameters/gridscan.py
+++ b/src/hyperion/parameters/gridscan.py
@@ -28,7 +28,7 @@ from hyperion.parameters.components import (
     WithScan,
     XyzStarts,
 )
-from hyperion.parameters.constants import CONST
+from hyperion.parameters.constants import CONST, I03Constants
 
 
 class GridCommon(
@@ -79,7 +79,7 @@ class GridCommon(
         ), "Detector distance must be filled before generating DetectorParams"
         os.makedirs(self.storage_directory, exist_ok=True)
         return DetectorParams(
-            detector_size_constants=self.detector,  # type: ignore # Will be cleaned up in #1307
+            detector_size_constants=I03Constants.DETECTOR,
             expected_energy_ev=self.demand_energy_ev,
             exposure_time=self.exposure_time_s,
             directory=self.storage_directory,

--- a/src/hyperion/parameters/rotation.py
+++ b/src/hyperion/parameters/rotation.py
@@ -24,7 +24,7 @@ from hyperion.parameters.components import (
     TemporaryIspybExtras,
     WithScan,
 )
-from hyperion.parameters.constants import CONST
+from hyperion.parameters.constants import CONST, I03Constants
 
 
 class RotationScan(
@@ -57,6 +57,7 @@ class RotationScan(
         assert self.detector_distance_mm is not None
         os.makedirs(self.storage_directory, exist_ok=True)
         return DetectorParams(
+            detector_size_constants=I03Constants.DETECTOR,
             expected_energy_ev=self.demand_energy_ev,
             exposure_time=self.exposure_time_s,
             directory=self.storage_directory,

--- a/tests/test_data/parameter_json_files/good_test_grid_with_edge_detect_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_grid_with_edge_detect_parameters.json
@@ -2,7 +2,6 @@
     "parameter_model_version": "5.0.0",
     "beamline": "BL03S",
     "insertion_prefix": "SR03S",
-    "detector": "EIGER2_X_16M",
     "zocalo_environment": "devrmq",
     "storage_directory": "/tmp",
     "file_name": "file_name",

--- a/tests/test_data/parameter_json_files/good_test_pin_centre_then_xray_centre_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_pin_centre_then_xray_centre_parameters.json
@@ -2,7 +2,6 @@
     "parameter_model_version": "5.0.0",
     "beamline": "BL03S",
     "insertion_prefix": "SR03S",
-    "detector": "EIGER2_X_16M",
     "zocalo_environment": "devrmq",
     "storage_directory": "/tmp",
     "file_name": "file_name",

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
@@ -4,7 +4,6 @@
     "det_dist_to_beam_converter_path": "tests/test_data/test_lookup_table.txt",
     "storage_directory": "/tmp/dls/i03/data/2024/cm31105-4/auto/123456/",
     "detector_distance_mm": 100.0,
-    "detector": "EIGER2_X_16M",
     "demand_energy_ev": 100,
     "exposure_time_s": 0.1,
     "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json
@@ -4,7 +4,6 @@
     "det_dist_to_beam_converter_path": "tests/test_data/test_lookup_table.txt",
     "storage_directory": "/tmp/dls/i03/data/2024/cm31105-4/auto/123456/",
     "detector_distance_mm": 100.0,
-    "detector": "EIGER2_X_16M",
     "demand_energy_ev": 100,
     "exposure_time_s": 0.1,
     "insertion_prefix": "SR03S",

--- a/tests/test_data/parameter_json_files/ispyb_gridscan_system_test_parameters.json
+++ b/tests/test_data/parameter_json_files/ispyb_gridscan_system_test_parameters.json
@@ -2,7 +2,6 @@
     "parameter_model_version": "5.0.0",
     "beamline": "BL03S",
     "insertion_prefix": "SR03S",
-    "detector": "EIGER2_X_16M",
     "zocalo_environment": "dev_artemis",
     "storage_directory": "/tmp",
     "file_name": "file_name",

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -12,8 +12,6 @@ from bluesky.utils import FailedStatus, Msg
 from dodal.beamlines import i03
 from dodal.common.beamlines.beamline_utils import clear_device
 from dodal.devices.detector.det_dim_constants import (
-    EIGER2_X_4M_DIMENSION,
-    EIGER_TYPE_EIGER2_X_4M,
     EIGER_TYPE_EIGER2_X_16M,
 )
 from dodal.devices.fast_grid_scan import ZebraFastGridScan
@@ -62,7 +60,6 @@ from hyperion.parameters.constants import CONST
 from hyperion.parameters.gridscan import ThreeDGridScan
 from tests.conftest import create_dummy_scan_spec
 
-from ...conftest import default_raw_params
 from ...system_tests.external_interaction.conftest import (
     TEST_RESULT_LARGE,
     TEST_RESULT_MEDIUM,
@@ -119,7 +116,7 @@ def mock_ispyb():
 class TestFlyscanXrayCentrePlan:
     td: TestData = TestData()
 
-    def test_given_full_parameters_dict_when_detector_name_used_and_converted_then_detector_constants_correct(
+    def test_eiger2_x_16_detector_specified(
         self,
         test_fgs_params: ThreeDGridScan,
     ):
@@ -127,11 +124,6 @@ class TestFlyscanXrayCentrePlan:
             test_fgs_params.detector_params.detector_size_constants.det_type_string
             == EIGER_TYPE_EIGER2_X_16M
         )
-        raw_params_dict = default_raw_params()
-        raw_params_dict["detector"] = EIGER_TYPE_EIGER2_X_4M
-        params: ThreeDGridScan = ThreeDGridScan(**raw_params_dict)
-        det_dimension = params.detector_params.detector_size_constants.det_dimension
-        assert det_dimension == EIGER2_X_4M_DIMENSION
 
     def test_when_run_gridscan_called_then_generator_returned(
         self,

--- a/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_panda_flyscan_xray_centre_plan.py
@@ -9,11 +9,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 from bluesky.utils import Msg
 from dodal.beamlines import i03
-from dodal.devices.detector.det_dim_constants import (
-    EIGER2_X_4M_DIMENSION,
-    EIGER_TYPE_EIGER2_X_4M,
-    EIGER_TYPE_EIGER2_X_16M,
-)
+from dodal.devices.detector.det_dim_constants import EIGER_TYPE_EIGER2_X_16M
 from dodal.devices.fast_grid_scan import PandAFastGridScan
 from dodal.devices.synchrotron import SynchrotronMode
 from ophyd.status import Status
@@ -53,7 +49,6 @@ from hyperion.log import ISPYB_LOGGER
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.gridscan import ThreeDGridScan
 
-from ...conftest import default_raw_params
 from ...system_tests.external_interaction.conftest import (
     TEST_RESULT_LARGE,
     TEST_RESULT_MEDIUM,
@@ -103,7 +98,7 @@ def ispyb_plan(test_panda_fgs_params):
 class TestFlyscanXrayCentrePlan:
     td: TestData = TestData()
 
-    def test_given_full_parameters_dict_when_detector_name_used_and_converted_then_detector_constants_correct(
+    def test_eiger2_x_16_detector_specified(
         self,
         test_panda_fgs_params: ThreeDGridScan,
     ):
@@ -111,11 +106,6 @@ class TestFlyscanXrayCentrePlan:
             test_panda_fgs_params.detector_params.detector_size_constants.det_type_string
             == EIGER_TYPE_EIGER2_X_16M
         )
-        raw_params_dict = default_raw_params()
-        raw_params_dict["detector"] = EIGER_TYPE_EIGER2_X_4M
-        params: ThreeDGridScan = ThreeDGridScan(**raw_params_dict)
-        det_dimension = params.detector_params.detector_size_constants.det_dimension
-        assert det_dimension == EIGER2_X_4M_DIMENSION
 
     def test_when_run_gridscan_called_then_generator_returned(
         self,
@@ -464,9 +454,7 @@ class TestFlyscanXrayCentrePlan:
                 wrapped_run_gridscan_and_move(), test_panda_fgs_params
             )
         )
-        app_to_comment: MagicMock = mock_subscriptions[
-            1
-        ].ispyb.append_to_comment  # type:ignore
+        app_to_comment: MagicMock = mock_subscriptions[1].ispyb.append_to_comment  # type:ignore
         app_to_comment.assert_called()
         call = app_to_comment.call_args_list[0]
         assert "Crystal 1: Strength 999999" in call.args[1]
@@ -509,9 +497,7 @@ class TestFlyscanXrayCentrePlan:
                 wrapped_run_gridscan_and_move(), test_panda_fgs_params
             )
         )
-        app_to_comment: MagicMock = mock_subscriptions[
-            1
-        ].ispyb.append_to_comment  # type:ignore
+        app_to_comment: MagicMock = mock_subscriptions[1].ispyb.append_to_comment  # type:ignore
         app_to_comment.assert_called()
         call = app_to_comment.call_args_list[0]
         assert "Zocalo found no crystals in this gridscan" in call.args[1]


### PR DESCRIPTION
Fixes #1307 

This change removes the `detector` attribute from the Hyperion request parameters

Link to dodal PR (if required): DiamondLightSource/dodal#588
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. Tests still pass
2. Confirm thing y happens
