### PR TITLE
(#1387) snapshot_directory request parameter can now be optionally specified

### DIFF
--- a/src/hyperion/parameters/components.py
+++ b/src/hyperion/parameters/components.py
@@ -12,7 +12,7 @@ from dodal.devices.detector import (
     TriggerMode,
 )
 from numpy.typing import NDArray
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic import BaseModel, Extra, Field, root_validator, validator
 from scanspec.core import AxesPoints
 from semver import Version
 
@@ -119,11 +119,11 @@ class HyperionParameters(BaseModel):
 
     @validator("parameter_model_version")
     def _validate_version(cls, version: ParameterVersion):
-        assert (
-            version >= ParameterVersion(major=PARAMETER_VERSION.major)
+        assert version >= ParameterVersion(
+            major=PARAMETER_VERSION.major
         ), f"Parameter version too old! This version of hyperion uses {PARAMETER_VERSION}"
-        assert (
-            version <= ParameterVersion(major=PARAMETER_VERSION.major + 1)
+        assert version <= ParameterVersion(
+            major=PARAMETER_VERSION.major + 1
         ), f"Parameter version too new! This version of hyperion uses {PARAMETER_VERSION}"
         return version
 
@@ -159,16 +159,23 @@ class DiffractionExperiment(HyperionParameters):
     run_number: int | None = Field(default=None, ge=0)
     ispyb_experiment_type: IspybExperimentType
     storage_directory: str
+    snapshot_directory: Path
+
+    @root_validator(pre=True)
+    def validate_snapshot_directory(cls, values):
+        snapshot_dir = values.get(
+            "snapshot_directory", Path(values["storage_directory"], "snapshots")
+        )
+        values["snapshot_directory"] = (
+            snapshot_dir if isinstance(snapshot_dir, Path) else Path(snapshot_dir)
+        )
+        return values
 
     @property
     def visit_directory(self) -> Path:
         return (
             Path(CONST.I03.BASE_DATA_DIR) / str(datetime.date.today().year) / self.visit
         )
-
-    @property
-    def snapshot_directory(self) -> Path:
-        return Path(self.storage_directory) / "snapshots"
 
     @property
     def num_images(self) -> int:

--- a/tests/unit_tests/parameters/test_parameter_model.py
+++ b/tests/unit_tests/parameters/test_parameter_model.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -86,3 +87,18 @@ def test_robot_load_then_centre_params():
     test_params = RobotLoadThenCentre(**params)
     assert test_params.visit_directory
     assert test_params.detector_params
+
+
+def test_default_snapshot_path(minimal_3d_gridscan_params):
+    gridscan_params = ThreeDGridScan(**minimal_3d_gridscan_params)
+    assert gridscan_params.snapshot_directory == Path(
+        "/tmp/dls/i03/data/2024/cm31105-4/xraycentring/123456/snapshots"
+    )
+
+    params_with_snapshot_path = dict(minimal_3d_gridscan_params)
+    params_with_snapshot_path["snapshot_directory"] = "/tmp/my_snapshots"
+
+    gridscan_params_with_snapshot_path = ThreeDGridScan(**params_with_snapshot_path)
+    assert gridscan_params_with_snapshot_path.snapshot_directory == Path(
+        "/tmp/my_snapshots"
+    )


### PR DESCRIPTION
Fixes #1387

Link to dodal PR (if required): #N/A
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. If the snapshot directory parameter is specified in the request then this path will be used to store the snapshots

