### PR TITLE
Fix unit tests after aperture change

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,8 @@ install_requires =
     ophyd == 1.9.0
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a3
-    blueapi >= 0.4.3-a1
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@4b53c861ac2babb4c96fcad55405083eb549e531
+    blueapi @ git+https://DiamondLightSource/blueapi.git@59507723e7e8abddbd5e0607f656d3c5fb3a14ac
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
 
 
 [options.entry_points]

--- a/tests/unit_tests/device_setup_plans/test_manipulate_sample.py
+++ b/tests/unit_tests/device_setup_plans/test_manipulate_sample.py
@@ -27,12 +27,10 @@ async def test_move_aperture_goes_to_correct_position(
     )
 
 
-@patch("bluesky.plan_stubs.abs_set")
 async def test_move_aperture_does_nothing_when_none_selected(
-    mock_set: MagicMock, aperture_scatterguard: ApertureScatterguard, RE: RunEngine
+    aperture_scatterguard: ApertureScatterguard, RE: RunEngine
 ):
     assert aperture_scatterguard.aperture_positions
-    await aperture_scatterguard.set(aperture_scatterguard.aperture_positions.ROBOT_LOAD)
-
-    RE(move_aperture_if_required(aperture_scatterguard, None))
-    mock_set.assert_not_called()
+    with patch("bluesky.plan_stubs.abs_set") as mock_set:
+        RE(move_aperture_if_required(aperture_scatterguard, None))
+        mock_set.assert_not_called()


### PR DESCRIPTION
A recent change in dodal required a change in BlueAPI, which hasn't had a release since the change, so breaks one of our tests. This PR pins blueapi to that commit, as well as fix one of the tests I added in #1336 

Link to dodal PR (if required): #XXX
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. Confirm tests pass