### PR TITLE
1417 Fix Ispyb DataCollections missing hardware values

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     ophyd == 1.9.0
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a3
-    blueapi @ git+https://DiamondLightSource/blueapi.git@59507723e7e8abddbd5e0607f656d3c5fb3a14ac
+    blueapi @ git+https://DiamondLightSource/blueapi.git@8bb938848ab11fe2aa8601519783ef6ad605dd40
     dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,8 @@ install_requires =
     ophyd == 1.9.0
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a3
-    blueapi >= 0.4.3-a1
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@4b53c861ac2babb4c96fcad55405083eb549e531
+    blueapi @ git+https://DiamondLightSource/blueapi.git@59507723e7e8abddbd5e0607f656d3c5fb3a14ac
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
 
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     ophyd == 1.9.0
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a3
-    blueapi @ git+https://DiamondLightSource/blueapi.git@8bb938848ab11fe2aa8601519783ef6ad605dd40
+    blueapi @ git+https://github.com/DiamondLightSource/blueapi.git@8bb938848ab11fe2aa8601519783ef6ad605dd40
     dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,6 +199,7 @@ def patch_async_motor(
     set_mock_value(motor.user_readback, initial_position)
     set_mock_value(motor.deadband, 0.001)
     set_mock_value(motor.motor_done_move, 1)
+    set_mock_value(motor.velocity, 1)
     return callback_on_mock_put(motor.user_setpoint, pass_on_mock(motor, call_log))
 
 
@@ -486,7 +487,7 @@ def aperture_scatterguard(RE):
         patch_async_motor(ap_sg.scatterguard.x),
         patch_async_motor(ap_sg.scatterguard.y),
     ):
-        RE(bps.abs_set(ap_sg, ap_sg.aperture_positions.SMALL))  # type:
+        RE(bps.abs_set(ap_sg, ap_sg.aperture_positions.SMALL))  # type: ignore
         set_mock_value(ap_sg.aperture.small, 1)
         yield ap_sg
 

--- a/tests/unit_tests/device_setup_plans/test_manipulate_sample.py
+++ b/tests/unit_tests/device_setup_plans/test_manipulate_sample.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from bluesky.run_engine import RunEngine
 from dodal.devices.aperturescatterguard import (
@@ -9,28 +9,25 @@ from dodal.devices.aperturescatterguard import (
 from hyperion.device_setup_plans.manipulate_sample import move_aperture_if_required
 
 
-@patch("bluesky.plan_stubs.abs_set")
 async def test_move_aperture_goes_to_correct_position(
-    mock_set: MagicMock, aperture_scatterguard: ApertureScatterguard, RE: RunEngine
+    aperture_scatterguard: ApertureScatterguard, RE: RunEngine
 ):
     assert aperture_scatterguard.aperture_positions
-
-    RE(
-        move_aperture_if_required(
-            aperture_scatterguard, AperturePositionGDANames.LARGE_APERTURE
+    with patch.object(aperture_scatterguard, "set") as mock_set:
+        RE(
+            move_aperture_if_required(
+                aperture_scatterguard, AperturePositionGDANames.LARGE_APERTURE
+            )
         )
-    )
-    mock_set.assert_called_once_with(
-        aperture_scatterguard,
-        aperture_scatterguard.aperture_positions.LARGE,
-        group="move_aperture",
-    )
+        mock_set.assert_called_once_with(
+            aperture_scatterguard.aperture_positions.LARGE,
+        )
 
 
 async def test_move_aperture_does_nothing_when_none_selected(
     aperture_scatterguard: ApertureScatterguard, RE: RunEngine
 ):
     assert aperture_scatterguard.aperture_positions
-    with patch("bluesky.plan_stubs.abs_set") as mock_set:
+    with patch.object(aperture_scatterguard, "set") as mock_set:
         RE(move_aperture_if_required(aperture_scatterguard, None))
         mock_set.assert_not_called()

--- a/tests/unit_tests/device_setup_plans/test_manipulate_sample.py
+++ b/tests/unit_tests/device_setup_plans/test_manipulate_sample.py
@@ -27,12 +27,10 @@ async def test_move_aperture_goes_to_correct_position(
     )
 
 
-@patch("bluesky.plan_stubs.abs_set")
 async def test_move_aperture_does_nothing_when_none_selected(
-    mock_set: MagicMock, aperture_scatterguard: ApertureScatterguard, RE: RunEngine
+    aperture_scatterguard: ApertureScatterguard, RE: RunEngine
 ):
     assert aperture_scatterguard.aperture_positions
-    await aperture_scatterguard.set(aperture_scatterguard.aperture_positions.ROBOT_LOAD)
-
-    RE(move_aperture_if_required(aperture_scatterguard, None))
-    mock_set.assert_not_called()
+    with patch("bluesky.plan_stubs.abs_set") as mock_set:
+        RE(move_aperture_if_required(aperture_scatterguard, None))
+        mock_set.assert_not_called()

--- a/tests/unit_tests/external_interaction/ispyb/test_ispyb_store.py
+++ b/tests/unit_tests/external_interaction/ispyb/test_ispyb_store.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+from epicscorelibs.ca.dbr import ca_float, ca_int, ca_str
+
+from hyperion.external_interaction.ispyb.ispyb_store import (
+    _convert_subclasses_to_builtins,
+)
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    (
+        (1.234, 1.234),
+        (ca_float(1.234), 1.234),
+        (1234, 1234),
+        (ca_int(1234), 1234),
+        ("test string", "test string"),
+        (ca_str("test string"), "test string"),
+        (None, None),
+        (np.float_(1.234), 1.234),  # aka np.double/np.float64
+        (np.int_(1234), 1234),
+        (np.str_("test string"), "test string"),
+    ),
+)
+def test_convert_to_builtin(input, expected):
+    """
+    See https://numpy.org/doc/stable/reference/arrays.scalars.html#sized-aliases
+    for all the various types that exist; the above is not a complete set
+    """
+    input_list = [input]
+    output_map = _convert_subclasses_to_builtins(input_list)
+    actual = output_map[0]
+    assert (
+        actual == expected
+    ), f"Conversion of {type(input)} {input} failed: {type(expected)} {expected} <=> {type(actual)} {actual}"
+    assert type(actual) == type(expected)


### PR DESCRIPTION
Fixes #1417 

Link to dodal PR (if required): #XXX
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. Tests pass
2. Ispyb DataCollections should now contain values for beam size, position, current gap, synchrotron mode etc. 
