### PR TITLE
Update DEV_ISPYB_DATABASE_CFG to point to ispyb-restore now that ispyb-dev is defunct

### DIFF
--- a/src/hyperion/parameters/constants.py
+++ b/src/hyperion/parameters/constants.py
@@ -14,7 +14,7 @@ class SimConstants:
     # this one is for unit tests
     ISPYB_CONFIG = "tests/test_data/test_config.cfg"
     # this one is for system tests
-    DEV_ISPYB_DATABASE_CFG = "/dls_sw/dasc/mariadb/credentials/ispyb-hyperion-dev.cfg"
+    DEV_ISPYB_DATABASE_CFG = "/dls_sw/dasc/mariadb/credentials/ispyb-restore.cfg"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Changes the credentials file to use ispyb-restore rather than ispyb-dev so that system tests continue to work

Link to dodal PR (if required): #N/A
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. System tests pass