### PR TITLE
349 rotation scan now collects OAV snapshots

### DIFF
--- a/src/hyperion/device_setup_plans/manipulate_sample.py
+++ b/src/hyperion/device_setup_plans/manipulate_sample.py
@@ -15,14 +15,22 @@ from hyperion.log import LOGGER
 LOWER_DETECTOR_SHUTTER_AFTER_SCAN = True
 
 
-def setup_sample_environment(
-    aperture_scatterguard: ApertureScatterguard,
-    aperture_position_gda_name: AperturePositionGDANames | None,
+def begin_sample_environment_setup(
     detector_motion: DetectorMotion,
-    backlight: Backlight,
     attenuator: Attenuator,
     transmission_fraction: float,
     detector_distance: float,
+    group="setup_senv",
+):
+    yield from bps.abs_set(detector_motion.shutter, 1, group=group)
+    yield from bps.abs_set(detector_motion.z, detector_distance, group=group)
+    yield from bps.abs_set(attenuator, transmission_fraction, group=group)
+
+
+def setup_sample_environment(
+    aperture_scatterguard: ApertureScatterguard,
+    aperture_position_gda_name: AperturePositionGDANames | None,
+    backlight: Backlight,
     group="setup_senv",
 ):
     """Move the aperture into required position, move out the backlight, retract the detector shutter,
@@ -31,10 +39,7 @@ def setup_sample_environment(
     yield from move_aperture_if_required(
         aperture_scatterguard, aperture_position_gda_name, group=group
     )
-    yield from bps.abs_set(detector_motion.shutter, 1, group=group)
-    yield from bps.abs_set(detector_motion.z, detector_distance, group=group)
     yield from bps.abs_set(backlight, BacklightPosition.OUT, group=group)
-    yield from bps.abs_set(attenuator, transmission_fraction, group=group)
 
 
 def move_aperture_if_required(

--- a/src/hyperion/device_setup_plans/manipulate_sample.py
+++ b/src/hyperion/device_setup_plans/manipulate_sample.py
@@ -22,6 +22,7 @@ def begin_sample_environment_setup(
     detector_distance: float,
     group="setup_senv",
 ):
+    """Start all sample environment changes that can be initiated before OAV snapshots are taken"""
     yield from bps.abs_set(detector_motion.shutter, 1, group=group)
     yield from bps.abs_set(detector_motion.z, detector_distance, group=group)
     yield from bps.abs_set(attenuator, transmission_fraction, group=group)
@@ -33,8 +34,7 @@ def setup_sample_environment(
     backlight: Backlight,
     group="setup_senv",
 ):
-    """Move the aperture into required position, move out the backlight, retract the detector shutter,
-    and set the attenuator to transmission."""
+    """Move the aperture into required position, move out the backlight."""
 
     yield from move_aperture_if_required(
         aperture_scatterguard, aperture_position_gda_name, group=group

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -12,6 +12,8 @@ from dodal.devices.dcm import DCM
 from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.flux import Flux
+from dodal.devices.oav.oav_detector import OAV
+from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.robot import BartRobot
 from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.smargon import Smargon
@@ -21,6 +23,7 @@ from dodal.devices.zebra import RotationDirection, Zebra
 from dodal.plans.check_topup import check_topup_and_wait_if_necessary
 
 from hyperion.device_setup_plans.manipulate_sample import (
+    begin_sample_environment_setup,
     cleanup_sample_environment,
     move_phi_chi_omega,
     move_x_y_z,
@@ -38,6 +41,11 @@ from hyperion.device_setup_plans.setup_zebra import (
     make_trigger_safe,
     setup_zebra_for_rotation,
 )
+from hyperion.experiment_plans.oav_snapshot_plan import (
+    OavSnapshotComposite,
+    oav_snapshot_plan,
+    setup_oav_snapshot_plan,
+)
 from hyperion.log import LOGGER
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.rotation import RotationScan
@@ -48,7 +56,7 @@ from hyperion.utils.context import device_composite_from_context
 
 
 @dataclasses.dataclass
-class RotationScanComposite:
+class RotationScanComposite(OavSnapshotComposite):
     """All devices which are directly or indirectly required by this plan"""
 
     aperture_scatterguard: ApertureScatterguard
@@ -64,6 +72,7 @@ class RotationScanComposite:
     synchrotron: Synchrotron
     s4_slit_gaps: S4SlitGaps
     zebra: Zebra
+    oav: OAV
 
     def __post_init__(self):
         """Ensure that aperture positions are loaded whenever this class is created."""
@@ -205,10 +214,30 @@ def rotation_scan_plan(
             wait=True,
         )
 
+        yield from bps.wait("move_gonio_to_start")
+        if params.take_snapshots:
+            yield from bps.wait("move_to_rotation_start")
+            yield from oav_snapshot_plan(
+                composite, params, OAVParameters(context="xrayCentring")
+            )
+
+            # Move to start again for rotation scan after snapshots
+            yield from bps.abs_set(
+                axis,
+                motion_values.start_motion_deg,
+                group="move_to_rotation_start",
+                wait=True,
+            )
+
+        yield from setup_sample_environment(
+            composite.aperture_scatterguard,
+            params.selected_aperture,
+            composite.backlight,
+        )
+
         LOGGER.info("Wait for any previous moves...")
         # wait for all the setup tasks at once
         yield from bps.wait("setup_senv")
-        yield from bps.wait("move_gonio_to_start")
         yield from bps.wait("move_to_rotation_start")
 
         # get some information for the ispyb deposition and trigger the callback
@@ -300,15 +329,13 @@ def rotation_scan(
         def rotation_with_cleanup_and_stage(params: RotationScan):
             assert composite.aperture_scatterguard.aperture_positions is not None
             LOGGER.info("setting up sample environment...")
-            yield from setup_sample_environment(
-                composite.aperture_scatterguard,
-                params.selected_aperture,
+            yield from begin_sample_environment_setup(
                 composite.detector_motion,
-                composite.backlight,
                 composite.attenuator,
                 params.transmission_frac,
                 params.detector_params.detector_distance,
             )
+            yield from setup_oav_snapshot_plan(composite, params)
             LOGGER.info("moving to position (if specified)")
             yield from move_x_y_z(
                 composite.smargon,

--- a/src/hyperion/parameters/components.py
+++ b/src/hyperion/parameters/components.py
@@ -144,6 +144,10 @@ class WithSnapshot(BaseModel):
     snapshot_directory: Path
     snapshot_omegas_deg: list[float] | None
 
+    @property
+    def take_snapshots(self) -> bool:
+        return bool(self.snapshot_omegas_deg)
+
 
 class DiffractionExperiment(HyperionParameters, WithSnapshot):
     """For all experiments which use beam"""

--- a/src/hyperion/utils/validation.py
+++ b/src/hyperion/utils/validation.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import bluesky.preprocessors as bpp
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i03
+from dodal.devices.oav.oav_parameters import OAVConfigParams
 from ophyd_async.core import set_mock_value
 
 from hyperion.device_setup_plans.read_hardware_for_setup import (
@@ -21,6 +22,8 @@ from hyperion.external_interaction.callbacks.rotation.nexus_callback import (
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.rotation import RotationScan
 
+DISPLAY_CONFIGURATION = "tests/devices/unit_tests/test_display.configuration"
+ZOOM_LEVELS_XML = "tests/devices/unit_tests/test_jCameraManZoomLevels.xml"
 TEST_DATA_DIRECTORY = Path("tests/test_data/nexus_files/rotation")
 TEST_METAFILE = "ins_8_5_meta.h5.gz"
 FAKE_DATAFILE = "../fake_data.h5"
@@ -88,10 +91,17 @@ def fake_create_rotation_devices():
     s4_slit_gaps = i03.s4_slit_gaps(fake_with_ophyd_sim=True)
     dcm = i03.dcm(fake_with_ophyd_sim=True)
     robot = i03.robot(fake_with_ophyd_sim=True)
+    oav = i03.oav(
+        fake_with_ophyd_sim=True,
+        params=OAVConfigParams(
+            zoom_params_file=ZOOM_LEVELS_XML, display_config=DISPLAY_CONFIGURATION
+        ),
+    )
 
     set_mock_value(smargon.omega.max_velocity, 131)
 
     set_mock_value(dcm.energy_in_kev.user_readback, 12700)
+    oav.zoom_controller.fvst.sim_put("1.0x")
 
     return RotationScanComposite(
         attenuator=attenuator,
@@ -107,6 +117,7 @@ def fake_create_rotation_devices():
         s4_slit_gaps=s4_slit_gaps,
         zebra=zebra,
         robot=robot,
+        oav=oav,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ from dodal.devices.detector.detector_motion import DetectorMotion
 from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import FastGridScanCommon
 from dodal.devices.flux import Flux
-from dodal.devices.oav.oav_detector import OAVConfigParams
+from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
 from dodal.devices.robot import BartRobot
 from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.smargon import Smargon
@@ -556,9 +556,11 @@ def fake_create_rotation_devices(
     s4_slit_gaps: S4SlitGaps,
     dcm: DCM,
     robot: BartRobot,
+    oav: OAV,
     done_status,
 ):
     set_mock_value(smargon.omega.max_velocity, 131)
+    oav.zoom_controller.fvst.sim_put("1.0x")
 
     return RotationScanComposite(
         attenuator=attenuator,
@@ -574,6 +576,7 @@ def fake_create_rotation_devices(
         s4_slit_gaps=s4_slit_gaps,
         zebra=zebra,
         robot=robot,
+        oav=oav,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from dodal.devices.eiger import EigerDetector
 from dodal.devices.fast_grid_scan import FastGridScanCommon
 from dodal.devices.flux import Flux
 from dodal.devices.oav.oav_detector import OAV, OAVConfigParams
+from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.robot import BartRobot
 from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.smargon import Smargon
@@ -560,7 +561,8 @@ def fake_create_rotation_devices(
     done_status,
 ):
     set_mock_value(smargon.omega.max_velocity, 131)
-    oav.zoom_controller.fvst.sim_put("1.0x")
+    oav.zoom_controller.onst.sim_put("1.0x")  # type: ignore
+    oav.zoom_controller.fvst.sim_put("5.0x")  # type: ignore
 
     return RotationScanComposite(
         attenuator=attenuator,
@@ -634,6 +636,11 @@ async def panda():
         }
     )
     return panda
+
+
+@pytest.fixture
+def oav_parameters_for_rotation(test_config_files) -> OAVParameters:
+    return OAVParameters(oav_config_json=test_config_files["oav_config_json"])
 
 
 async def async_status_done():

--- a/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
@@ -734,6 +734,11 @@ def compare_actual_and_expected(
 
 
 @pytest.mark.s03
+def test_ispyb_deposition_in_rotation_plan_snapshots_in_parameters():
+    assert False, "TODO"
+
+
+@pytest.mark.s03
 @patch("bluesky.plan_stubs.wait")
 def test_ispyb_deposition_in_rotation_plan(
     bps_wait,

--- a/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
@@ -59,8 +59,8 @@ from .conftest import raw_params_from_file
 
 EXPECTED_DATACOLLECTION_FOR_ROTATION = {
     "wavelength": 0.71,
-    "beamSizeAtSampleX": 20,
-    "beamSizeAtSampleY": 20,
+    "beamSizeAtSampleX": 0.02,
+    "beamSizeAtSampleY": 0.02,
     "exposureTime": 0.023,
     "undulatorGap1": 1.12,
     "synchrotronMode": SynchrotronMode.USER.value,
@@ -446,7 +446,9 @@ def composite_for_rotation_scan(fake_create_rotation_devices: RotationScanCompos
         fake_create_rotation_devices.dcm.energy_in_kev.user_readback,
         energy_ev / 1000,  # pyright: ignore
     )
-    set_mock_value(fake_create_rotation_devices.undulator.current_gap, 1.12)  # pyright: ignore
+    set_mock_value(
+        fake_create_rotation_devices.undulator.current_gap, 1.12
+    )  # pyright: ignore
     set_mock_value(
         fake_create_rotation_devices.synchrotron.synchrotron_mode,
         SynchrotronMode.USER,
@@ -646,12 +648,12 @@ def test_ispyb_deposition_in_gridscan(
         "axisstart": 0.0,
         "axisrange": 0,
         "axisend": 0,
-        "focalspotsizeatsamplex": 20.0,
-        "focalspotsizeatsampley": 20.0,
+        "focalspotsizeatsamplex": 0.02,
+        "focalspotsizeatsampley": 0.02,
         "slitgapvertical": 0.1,
         "slitgaphorizontal": 0.1,
-        "beamsizeatsamplex": 20.0,
-        "beamsizeatsampley": 20.0,
+        "beamsizeatsamplex": 0.02,
+        "beamsizeatsampley": 0.02,
         "transmission": 49.118,
         "datacollectionnumber": 1,
         "detectordistance": 100.0,
@@ -679,7 +681,7 @@ def test_ispyb_deposition_in_gridscan(
         ispyb_ids.data_collection_ids[0],
         "Hyperion: Xray centring - Diffraction grid scan of 20 by 12 "
         "images in 20.0 um by 20.0 um steps. Top left (px): [100,161], "
-        "bottom right (px): [239,244].",
+        "bottom right (px): [239,244]. Aperture: Small. ",
     )
     compare_actual_and_expected(
         ispyb_ids.data_collection_ids[0],
@@ -733,7 +735,7 @@ def test_ispyb_deposition_in_gridscan(
         ispyb_ids.data_collection_ids[1],
         "Hyperion: Xray centring - Diffraction grid scan of 20 by 11 "
         "images in 20.0 um by 20.0 um steps. Top left (px): [100,165], "
-        "bottom right (px): [239,241].",
+        "bottom right (px): [239,241]. Aperture: Small. ",
     )
     position_id = fetch_datacollection_attribute(
         ispyb_ids.data_collection_ids[1], DATA_COLLECTION_COLUMN_MAP["positionid"]
@@ -781,7 +783,8 @@ def test_ispyb_deposition_in_rotation_plan(
     dcid = ispyb_cb.ispyb_ids.data_collection_ids[0]
     assert dcid is not None
     assert (
-        fetch_comment(dcid) == "Sample position: (1.0, 2.0, 3.0) test Aperture: Small"
+        fetch_comment(dcid)
+        == "Sample position: (1.0, 2.0, 3.0) test  Aperture: Small. "
     )
 
     expected_values = EXPECTED_DATACOLLECTION_FOR_ROTATION | {

--- a/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_rotation_scan_parameters.json
@@ -25,6 +25,7 @@
     "y_start_um": 2.0,
     "z_start_um": 3.0,
     "selected_aperture": "SMALL_APERTURE",
+    "snapshot_omegas_deg": [0, 90, 180, 270],
     "ispyb_extras": {
         "xtal_snapshots_omega_start": [
             "test_1_y",

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]
+
+
+@pytest.fixture(autouse=True)
+def patch_open_to_prevent_dls_reads_in_tests():
+    unpatched_open = open
+
+    def patched_open(*args, **kwargs):
+        requested_path = Path(args[0])
+        if requested_path.is_absolute():
+            for p in BANNED_PATHS:
+                assert not requested_path.is_relative_to(
+                    p
+                ), f"Attempt to open {requested_path} from inside a unit test"
+        return unpatched_open(*args, **kwargs)
+
+    with patch("builtins.open", side_effect=patched_open):
+        yield []

--- a/tests/unit_tests/experiment_plans/test_oav_snapshot_plan.py
+++ b/tests/unit_tests/experiment_plans/test_oav_snapshot_plan.py
@@ -1,9 +1,14 @@
+import dataclasses
 from datetime import datetime
 from unittest.mock import patch
 
 import pytest
+from dodal.devices.aperturescatterguard import ApertureScatterguard
+from dodal.devices.backlight import Backlight
+from dodal.devices.oav.oav_detector import OAV
 from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.oav.utils import ColorMode
+from dodal.devices.smargon import Smargon
 
 from hyperion.experiment_plans.oav_snapshot_plan import (
     OAV_SNAPSHOT_GROUP,
@@ -25,10 +30,23 @@ def oav_snapshot_params():
     )
 
 
+@dataclasses.dataclass
+class CompositeImpl(OavSnapshotComposite):
+    smargon: Smargon
+    oav: OAV
+    aperture_scatterguard: ApertureScatterguard
+    backlight: Backlight
+
+
 @pytest.fixture
-def oav_snapshot_composite(smargon, oav):
+def oav_snapshot_composite(smargon, oav, aperture_scatterguard, backlight):
     oav.zoom_controller.fvst.sim_put("5.0x")
-    return OavSnapshotComposite(smargon=smargon, oav=oav)
+    return CompositeImpl(
+        smargon=smargon,
+        oav=oav,
+        aperture_scatterguard=aperture_scatterguard,
+        backlight=backlight,
+    )
 
 
 @patch("hyperion.experiment_plans.oav_snapshot_plan.datetime", spec=datetime)

--- a/tests/unit_tests/experiment_plans/test_oav_snapshot_plan.py
+++ b/tests/unit_tests/experiment_plans/test_oav_snapshot_plan.py
@@ -11,7 +11,7 @@ from dodal.devices.oav.utils import ColorMode
 from dodal.devices.smargon import Smargon
 
 from hyperion.experiment_plans.oav_snapshot_plan import (
-    OAV_SNAPSHOT_GROUP,
+    OAV_SNAPSHOT_SETUP_SHOT,
     OavSnapshotComposite,
     oav_snapshot_plan,
 )
@@ -109,24 +109,27 @@ def test_oav_snapshot_plan_issues_rotations_and_generates_events(
             lambda msg: msg.command == "set"
             and msg.obj.name == "smargon-omega"
             and msg.args[0] == expected["omega"]
-            and msg.kwargs["group"] == OAV_SNAPSHOT_GROUP,
+            and msg.kwargs["group"] == OAV_SNAPSHOT_SETUP_SHOT,
         )
         msgs = sim_run_engine.assert_message_and_return_remaining(
             msgs,
             lambda msg: msg.command == "set"
             and msg.obj.name == "oav_snapshot_filename"
-            and msg.args[0] == expected["filename"],
-        )
-        msgs = sim_run_engine.assert_message_and_return_remaining(
-            msgs,
-            lambda msg: msg.command == "trigger"
-            and msg.obj.name == "oav_snapshot"
-            and msg.kwargs["group"] == OAV_SNAPSHOT_GROUP,
+            and msg.args[0] == expected["filename"]
+            and msg.kwargs["group"] == OAV_SNAPSHOT_SETUP_SHOT,
         )
         msgs = sim_run_engine.assert_message_and_return_remaining(
             msgs,
             lambda msg: msg.command == "wait"
-            and msg.kwargs["group"] == OAV_SNAPSHOT_GROUP,
+            and msg.kwargs["group"] == OAV_SNAPSHOT_SETUP_SHOT,
+        )
+        msgs = sim_run_engine.assert_message_and_return_remaining(
+            msgs,
+            lambda msg: msg.command == "trigger" and msg.obj.name == "oav_snapshot",
+        )
+        msgs = sim_run_engine.assert_message_and_return_remaining(
+            msgs,
+            lambda msg: msg.command == "wait" and msg.kwargs["group"] is None,
         )
         msgs = sim_run_engine.assert_message_and_return_remaining(
             msgs,

--- a/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
@@ -8,6 +8,7 @@ from bluesky.run_engine import RunEngine
 from dodal.devices.aperturescatterguard import AperturePositions, ApertureScatterguard
 from dodal.devices.backlight import BacklightPosition
 from dodal.devices.oav.oav_parameters import OAVParameters
+from dodal.devices.smargon import Smargon
 from dodal.devices.synchrotron import SynchrotronMode
 from dodal.devices.zebra import Zebra
 from ophyd_async.core import get_mock_put, set_mock_value
@@ -203,7 +204,8 @@ async def test_full_rotation_plan_smargon_settings(
     assert await smargon.z.user_readback.get_value() == params.z_start_um
     assert (
         # 4 * snapshots, restore omega, 1 * rotation sweep
-        omega_set.call_count == 4 + 1 + 1
+        omega_set.call_count
+        == 4 + 1 + 1
     )
     # 1 to max vel in outer plan, 1 to max vel in setup_oav_snapshot_plan, 1 set before rotation, 1 restore in cleanup plan
     assert omega_velocity_set.call_count == 4

--- a/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
@@ -11,7 +11,7 @@ from dodal.devices.oav.oav_parameters import OAVParameters
 from dodal.devices.smargon import Smargon
 from dodal.devices.synchrotron import SynchrotronMode
 from dodal.devices.zebra import Zebra
-from ophyd_async.core import get_mock_put, set_mock_value
+from ophyd_async.core import get_mock_put
 
 from hyperion.experiment_plans.oav_snapshot_plan import (
     OAV_SNAPSHOT_GROUP,


### PR DESCRIPTION
Addresses the remaining parts of #349 

Link to dodal PR (if required): #N/A
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. When supplied with `snapshot_omegas_deg` as an array of up to 4 snapshot angles, and  `snapshot_directory` in the request parameters to a rotation scan, OAV  snapshots will be acquired prior to the rotation scan at the requested angles and deposited in ispyb
2. If `snapshot_omegas_deg` is empty or missing, no snapshots will be acquired and snapshot filenames will be registered in ispyb as specified by the `ispyb_extras.xtal_snapshots_omega_start` array
