### PR TITLE
Pin dodal hash to prevent CI breakage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     bluesky >= 1.13.0a3
     blueapi >= 0.4.3-rc1
     # needed for CI while xpress is broken, remove on merging
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@fb6f9b6fa0bdb57c9841b4f4463e7ba4e47b8ada
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@b6b22383cfb31cb5e4c5b88de0c785463cc1c8e6
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This pins dodal to the current head of  `229_convert_xbpm_feedback_to_ophyd_async` which excludes the xpress3 ophyd_async changes which currently cause issues with hyperion tests, until they can be merged.

