### PR TITLE
Add a plan to do multiple rotation scans

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ console_scripts =
 
 [options.extras_require]
 dev =
+    annotated_types
     ophyd-async
     GitPython
     black

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     bluesky >= 1.13.0a3
     blueapi >= 0.4.3-rc1
     # needed for CI while xpress is broken, remove on merging
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@695e9b2b993681163cf6fc0f8831fa1e13eb2416
 
 [options.entry_points]
 console_scripts =

--- a/src/hyperion/device_setup_plans/setup_zebra.py
+++ b/src/hyperion/device_setup_plans/setup_zebra.py
@@ -97,8 +97,7 @@ def setup_zebra_for_rotation(
             "Disallowed rotation direction provided to Zebra setup plan. "
             "Use RotationDirection.POSITIVE or RotationDirection.NEGATIVE."
         )
-    # TODO Actually set the rotation direction in here.
-    # See https://github.com/DiamondLightSource/hyperion/issues/1273
+    yield from bps.abs_set(zebra.pc.dir, direction.value, group=group)
     LOGGER.info("ZEBRA SETUP: START")
     # must be on for shutter trigger to be enabled
     yield from bps.abs_set(zebra.inputs.soft_in_1, SoftInState.YES, group=group)

--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -166,7 +166,6 @@ def kickoff_and_complete_gridscan(
     gridscan: FastGridScanCommon,
     eiger: EigerDetector,
     synchrotron: Synchrotron,
-    zocalo_environment: str,
     scan_points: list[AxesPoints[Axis]],
     scan_start_indices: list[int],
 ):
@@ -175,7 +174,6 @@ def kickoff_and_complete_gridscan(
     @bpp.run_decorator(
         md={
             "subplan_name": CONST.PLAN.DO_FGS,
-            "zocalo_environment": zocalo_environment,
             "scan_points": scan_points,
             "scan_start_indices": scan_start_indices,
         }
@@ -266,7 +264,6 @@ def run_gridscan(
         fgs_motors,
         fgs_composite.eiger,
         fgs_composite.synchrotron,
-        parameters.zocalo_environment,
         [parameters.scan_points_first_grid, parameters.scan_points_second_grid],
         parameters.scan_indices,
     )
@@ -367,6 +364,7 @@ def flyscan_xray_centre(
         md={
             "subplan_name": CONST.PLAN.GRIDSCAN_OUTER,
             CONST.TRIGGER.ZOCALO: CONST.PLAN.DO_FGS,
+            "zocalo_environment": parameters.zocalo_environment,
             "hyperion_parameters": parameters.json(),
             "activate_callbacks": [
                 "GridscanNexusFileCallback",

--- a/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/panda_flyscan_xray_centre_plan.py
@@ -126,7 +126,6 @@ def run_gridscan(
         fgs_motors,
         fgs_composite.eiger,
         fgs_composite.synchrotron,
-        parameters.zocalo_environment,
         [parameters.scan_points_first_grid, parameters.scan_points_second_grid],
         parameters.scan_indices,
     )
@@ -281,6 +280,7 @@ def panda_flyscan_xray_centre(
             "subplan_name": CONST.PLAN.GRIDSCAN_OUTER,
             CONST.TRIGGER.ZOCALO: CONST.PLAN.DO_FGS,
             "hyperion_parameters": parameters.json(),
+            "zocalo_environment": parameters.zocalo_environment,
             "activate_callbacks": [
                 "GridscanNexusFileCallback",
             ],

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -109,10 +109,9 @@ class RotationMotionProfile:
 
 
 def calculate_motion_profile(
-    params: RotationScanCore,
+    params: RotationScan,
     motor_time_to_speed_s: float,
     max_velocity_deg_s: float,
-    exposure_time_s: float,
 ) -> RotationMotionProfile:
     """Calculates the various numbers needed for motions in the rotation scan.
     Rotates through "scan width" plus twice an "offset" to take into account
@@ -126,6 +125,7 @@ def calculate_motion_profile(
     num_images = params.num_images
     shutter_time_s = params.shutter_opening_time_s
     image_width_deg = params.rotation_increment_deg
+    exposure_time_s = params.exposure_time_s
     motor_time_to_speed_s *= ACCELERATION_MARGIN
     start_scan_deg = params.omega_start_deg
 
@@ -308,9 +308,7 @@ def rotation_scan(
             yield from bps.rd(composite.smargon.omega.max_velocity)
             or DEFAULT_MAX_VELOCITY
         )
-        motion_values = calculate_motion_profile(
-            params, motor_time_to_speed, max_vel, params.exposure_time_s
-        )
+        motion_values = calculate_motion_profile(params, motor_time_to_speed, max_vel)
 
         eiger: EigerDetector = composite.eiger
         eiger.set_detector_parameters(params.detector_params)
@@ -346,26 +344,37 @@ def multi_rotation_scan(
     max_vel = (
         yield from bps.rd(composite.smargon.omega.max_velocity) or DEFAULT_MAX_VELOCITY
     )
+    assert composite.aperture_scatterguard.aperture_positions is not None
+    LOGGER.info("setting up sample environment...")
+    yield from setup_sample_environment(
+        composite.aperture_scatterguard,
+        outer_parameters.selected_aperture,
+        composite.detector_motion,
+        composite.backlight,
+        composite.attenuator,
+        outer_parameters.transmission_frac,
+        outer_parameters.detector_params.detector_distance,
+    )
 
     @bpp.stage_decorator([eiger])
     @bpp.finalize_decorator(lambda: cleanup_plan(composite, max_vel))
     def _multi_rotation_scan():
-        for scan_parameters in outer_parameters.rotation_scans:
+        for single_scan in outer_parameters.single_rotation_scans:
 
             @bpp.set_run_key_decorator("rotation_scan")
             @bpp.run_decorator(  # attach experiment metadata to the start document
                 md={
                     "subplan_name": CONST.PLAN.ROTATION_OUTER,
                     CONST.TRIGGER.ZOCALO: CONST.PLAN.ROTATION_MAIN,
-                    "hyperion_parameters": outer_parameters.json(),
+                    "hyperion_parameters": single_scan.json(),
                     "activate_callbacks": [
                         "RotationISPyBCallback",
                         "RotationNexusFileCallback",
                     ],
                 }
             )
-            def rotation_scan_plan_with_stage_and_cleanup(
-                params: RotationScanCore,
+            def rotation_scan_core(
+                params: RotationScan,
             ):
                 motor_time_to_speed = yield from bps.rd(
                     composite.smargon.omega.acceleration
@@ -375,33 +384,14 @@ def multi_rotation_scan(
                     or DEFAULT_MAX_VELOCITY
                 )
                 motion_values = calculate_motion_profile(
-                    params,
+                    single_scan,
                     motor_time_to_speed,
                     max_vel,
-                    outer_parameters.exposure_time_s,
                 )
 
-                def rotation_with_cleanup_and_stage(
-                    params: RotationScanCore,
-                ):
-                    assert (
-                        composite.aperture_scatterguard.aperture_positions is not None
-                    )
-                    LOGGER.info("setting up sample environment...")
-                    yield from setup_sample_environment(
-                        composite.aperture_scatterguard,
-                        outer_parameters.selected_aperture,
-                        composite.detector_motion,
-                        composite.backlight,
-                        composite.attenuator,
-                        params.transmission_frac,
-                        outer_parameters.detector_params.detector_distance,
-                    )
-                    yield from move_and_rotation(composite, params, motion_values)
+                yield from move_and_rotation(composite, params, motion_values)
 
-                LOGGER.info("setting up and staging eiger...")
-                yield from rotation_with_cleanup_and_stage(scan_parameters)
+            yield from rotation_scan_core(single_scan)
 
-            yield from rotation_scan_plan_with_stage_and_cleanup(scan_parameters)
-
+    LOGGER.info("setting up and staging eiger...")
     yield from _multi_rotation_scan()

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -43,7 +43,6 @@ from hyperion.parameters.constants import CONST
 from hyperion.parameters.rotation import (
     MultiRotationScan,
     RotationScan,
-    RotationScanCore,
 )
 from hyperion.utils.aperturescatterguard import (
     load_default_aperture_scatterguard_positions_if_unset,
@@ -87,11 +86,6 @@ DEFAULT_MAX_VELOCITY = 120
 # Use a slightly larger time to acceleration than EPICS as it's better to be cautious
 ACCELERATION_MARGIN = 1.5
 
-ROTATION_DIRECTION = {
-    RotationDirection.POSITIVE: 1,
-    RotationDirection.NEGATIVE: -1,
-}
-
 
 @dataclasses.dataclass
 class RotationMotionProfile:
@@ -121,7 +115,7 @@ def calculate_motion_profile(
     See https://github.com/DiamondLightSource/hyperion/wiki/rotation-scan-geometry
     for a simple pictorial explanation."""
 
-    direction = ROTATION_DIRECTION[params.rotation_direction]
+    direction = params.rotation_direction.multiplier
     num_images = params.num_images
     shutter_time_s = params.shutter_opening_time_s
     image_width_deg = params.rotation_increment_deg
@@ -166,7 +160,7 @@ def calculate_motion_profile(
 
 def rotation_scan_plan(
     composite: RotationScanComposite,
-    params: RotationScanCore,
+    params: RotationScan,
     motion_values: RotationMotionProfile,
 ):
     """A plan to collect diffraction images from a sample continuously rotating about
@@ -260,7 +254,7 @@ def cleanup_plan(composite: RotationScanComposite, max_vel: float, **kwargs):
 
 def move_and_rotation(
     composite: RotationScanComposite,
-    params: RotationScanCore,
+    params: RotationScan,
     motion_values: RotationMotionProfile,
 ):
     LOGGER.info("moving to position (if specified)")

--- a/src/hyperion/external_interaction/callbacks/zocalo_callback.py
+++ b/src/hyperion/external_interaction/callbacks/zocalo_callback.py
@@ -42,10 +42,11 @@ class ZocaloCallback(CallbackBase):
         ISPYB_LOGGER.info("Zocalo handler received start document.")
         if triggering_plan := doc.get(CONST.TRIGGER.ZOCALO):
             self.triggering_plan = triggering_plan
-        if self.triggering_plan and doc.get("subplan_name") == self.triggering_plan:
             assert isinstance(zocalo_environment := doc.get("zocalo_environment"), str)
             ISPYB_LOGGER.info(f"Zocalo environment set to {zocalo_environment}.")
             self.zocalo_interactor = ZocaloTrigger(zocalo_environment)
+
+        if self.triggering_plan and doc.get("subplan_name") == self.triggering_plan:
             self.run_uid = doc.get("uid")
             assert isinstance(scan_points := doc.get("scan_points"), list)
             if (

--- a/src/hyperion/parameters/components.py
+++ b/src/hyperion/parameters/components.py
@@ -120,11 +120,11 @@ class HyperionParameters(BaseModel):
 
     @validator("parameter_model_version")
     def _validate_version(cls, version: ParameterVersion):
-        assert version >= ParameterVersion(
-            major=PARAMETER_VERSION.major
+        assert (
+            version >= ParameterVersion(major=PARAMETER_VERSION.major)
         ), f"Parameter version too old! This version of hyperion uses {PARAMETER_VERSION}"
-        assert version <= ParameterVersion(
-            major=PARAMETER_VERSION.major + 1
+        assert (
+            version <= ParameterVersion(major=PARAMETER_VERSION.major + 1)
         ), f"Parameter version too new! This version of hyperion uses {PARAMETER_VERSION}"
         return version
 
@@ -165,6 +165,7 @@ class DiffractionExperiment(HyperionParameters, WithSnapshot):
     selected_aperture: AperturePositionGDANames | None = Field(default=None)
     ispyb_experiment_type: IspybExperimentType
     storage_directory: str
+    transmission_frac: float
 
     @root_validator(pre=True)
     def validate_snapshot_directory(cls, values):

--- a/src/hyperion/parameters/rotation.py
+++ b/src/hyperion/parameters/rotation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 
+import numpy as np
 from dodal.devices.detector import DetectorParams
 from dodal.devices.detector.det_dist_to_beam_converter import (
     DetectorDistanceToBeamXYConverter,
@@ -27,8 +28,7 @@ from hyperion.parameters.components import (
 from hyperion.parameters.constants import CONST, I03Constants
 
 
-class RotationScan(
-    DiffractionExperimentWithSample,
+class RotationScanCore(
     WithScan,
     OptionalGonioAngleStarts,
     OptionalXyzStarts,
@@ -45,6 +45,8 @@ class RotationScan(
     transmission_frac: float
     ispyb_extras: TemporaryIspybExtras | None
 
+
+class RotationScan(DiffractionExperimentWithSample, RotationScanCore):
     @property
     def detector_params(self):
         self.det_dist_to_beam_converter_path = (
@@ -77,6 +79,7 @@ class RotationScan(
 
     @property
     def ispyb_params(self):  # pyright: ignore
+        pos = np.array([self.x_start_um, self.y_start_um, self.z_start_um])
         return RotationIspybParams(
             visit_path=str(self.visit_directory),
             comment=self.comment,
@@ -86,6 +89,7 @@ class RotationScan(
                 else []
             ),
             ispyb_experiment_type=self.ispyb_experiment_type,
+            position=pos if np.all(pos) else None,
         )
 
     @property
@@ -104,3 +108,7 @@ class RotationScan(
     @property
     def num_images(self) -> int:
         return int(self.scan_width_deg / self.rotation_increment_deg)
+
+
+class MultiRotationScan(DiffractionExperimentWithSample):
+    rotation_scans: list[RotationScanCore]

--- a/src/hyperion/parameters/rotation.py
+++ b/src/hyperion/parameters/rotation.py
@@ -133,7 +133,7 @@ class MultiRotationScan(RotationScanGeneric, SplitScan):
     def num_images(self):
         return sum(
             [
-                scan.scan_width_deg / self.rotation_increment_deg
+                int(scan.scan_width_deg / self.rotation_increment_deg)
                 for scan in self.rotation_scans
             ]
         )

--- a/src/hyperion/parameters/rotation.py
+++ b/src/hyperion/parameters/rotation.py
@@ -47,6 +47,10 @@ class RotationScanCore(
 
 
 class RotationScan(DiffractionExperimentWithSample, RotationScanCore):
+    ispyb_experiment_type: IspybExperimentType = Field(
+        default=IspybExperimentType.ROTATION
+    )
+
     @property
     def detector_params(self):
         self.det_dist_to_beam_converter_path = (
@@ -111,4 +115,4 @@ class RotationScan(DiffractionExperimentWithSample, RotationScanCore):
 
 
 class MultiRotationScan(DiffractionExperimentWithSample):
-    rotation_scans: list[RotationScanCore]
+    rotation_scans: tuple[RotationScanCore, ...]

--- a/src/hyperion/utils/validation.py
+++ b/src/hyperion/utils/validation.py
@@ -89,6 +89,7 @@ def fake_create_rotation_devices():
     mock_omega_sets = MagicMock(return_value=Status(done=True, success=True))
     mock_omega_velocity_sets = MagicMock(return_value=Status(done=True, success=True))
 
+    smargon.omega.user_readback.sim_put(0)  # type: ignore
     smargon.omega.velocity.set = mock_omega_velocity_sets
     smargon.omega.set = mock_omega_sets
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ from hyperion.log import (
     do_default_logging_setup,
 )
 from hyperion.parameters.gridscan import GridScanWithEdgeDetect, ThreeDGridScan
-from hyperion.parameters.rotation import RotationScan
+from hyperion.parameters.rotation import MultiRotationScan, RotationScan
 
 i03.DAQ_CONFIGURATION_PATH = "tests/test_data/test_daq_configuration"
 
@@ -239,6 +239,15 @@ def test_rotation_params_nomove():
     return RotationScan(
         **raw_params_from_file(
             "tests/test_data/parameter_json_files/good_test_rotation_scan_parameters_nomove.json"
+        )
+    )
+
+
+@pytest.fixture
+def test_multi_rotation_params():
+    return MultiRotationScan(
+        **raw_params_from_file(
+            "tests/test_data/parameter_json_files/good_test_multi_rotation_scan_parameters.json"
         )
     )
 

--- a/tests/test_data/parameter_json_files/good_test_multi_rotation_scan_parameters.json
+++ b/tests/test_data/parameter_json_files/good_test_multi_rotation_scan_parameters.json
@@ -1,0 +1,50 @@
+{
+    "parameter_model_version": "5.0.0",
+    "comment": "test",
+    "det_dist_to_beam_converter_path": "tests/test_data/test_lookup_table.txt",
+    "storage_directory": "/tmp/dls/i03/data/2024/cm31105-4/auto/123456/",
+    "detector_distance_mm": 100.0,
+    "demand_energy_ev": 100,
+    "exposure_time_s": 0.1,
+    "insertion_prefix": "SR03S",
+    "file_name": "file_name",
+    "run_number": 0,
+    "sample_id": 123456,
+    "shutter_opening_time_s": 0.6,
+    "visit": "cm31105-4",
+    "zocalo_environment": "dev_artemis",
+    "transmission_frac": 0.1,
+    "rotation_increment_deg": 0.1,
+    "selected_aperture": "SMALL_APERTURE",
+    "rotation_scans": [{
+        "rotation_axis": "omega",
+        "rotation_direction": "Negative",
+        "scan_width_deg": 180.0,
+        "omega_start_deg": 0.0,
+        "phi_start_deg": 0.47,
+        "chi_start_deg": 23.85,
+        "x_start_um": 1.0,
+        "y_start_um": 2.0,
+        "z_start_um": 3.0
+    },{
+        "rotation_axis": "omega",
+        "rotation_direction": "Negative",
+        "scan_width_deg": 90.0,
+        "omega_start_deg": 180.0,
+        "phi_start_deg": 0.47,
+        "chi_start_deg": 4.7,
+        "x_start_um": 3.0,
+        "y_start_um": 2.0,
+        "z_start_um": 1.0
+    },{
+        "rotation_axis": "omega",
+        "rotation_direction": "Positive",
+        "scan_width_deg": 360.0,
+        "omega_start_deg": 270.0,
+        "phi_start_deg": 0.47,
+        "chi_start_deg": 45,
+        "x_start_um": 6.0,
+        "y_start_um": 7.0,
+        "z_start_um": 8.0
+    }]
+}

--- a/tests/unit_tests/experiment_plans/conftest.py
+++ b/tests/unit_tests/experiment_plans/conftest.py
@@ -60,6 +60,24 @@ BASIC_POST_SETUP_DOC = {
 }
 
 
+@pytest.fixture
+def sim_run_engine_for_rotation(sim_run_engine):
+    sim_run_engine.add_handler(
+        "read",
+        "synchrotron-synchrotron_mode",
+        lambda msg: {"values": {"value": SynchrotronMode.USER}},
+    )
+    sim_run_engine.add_handler(
+        "read",
+        "synchrotron-top_up_start_countdown",
+        lambda msg: {"values": {"value": -1}},
+    )
+    sim_run_engine.add_handler(
+        "read", "smargon_omega", lambda msg: {"values": {"value": -1}}
+    )
+    return sim_run_engine
+
+
 def mock_zocalo_trigger(zocalo: ZocaloResults, result):
     @AsyncStatus.wrap
     async def mock_complete(results):

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -498,7 +498,6 @@ class TestFlyscanXrayCentrePlan:
                     fgs,
                     fake_fgs_composite.eiger,
                     fake_fgs_composite.synchrotron,
-                    "zocalo environment",
                     [
                         test_fgs_params.scan_points_first_grid,
                         test_fgs_params.scan_points_second_grid,
@@ -514,7 +513,6 @@ class TestFlyscanXrayCentrePlan:
                 fgs,
                 fake_fgs_composite.eiger,
                 fake_fgs_composite.synchrotron,
-                "zocalo environment",
                 [
                     test_fgs_params.scan_points_first_grid,
                     test_fgs_params.scan_points_second_grid,
@@ -837,6 +835,7 @@ def test_kickoff_and_complete_gridscan_triggers_zocalo(
     RE: RunEngine,
     fake_fgs_composite: FlyScanXRayCentreComposite,
 ):
+    mock_zocalo_trigger_class.return_value = (mock_zocalo_trigger := MagicMock())
     id_1, id_2 = 100, 200
 
     _, ispyb_cb = create_gridscan_callbacks()
@@ -847,10 +846,10 @@ def test_kickoff_and_complete_gridscan_triggers_zocalo(
     assert isinstance(zocalo_cb := ispyb_cb.emit_cb, ZocaloCallback)
     zocalo_env = "dev_env"
 
-    zocalo_cb.start({CONST.TRIGGER.ZOCALO: CONST.PLAN.DO_FGS})  # type: ignore
+    zocalo_cb.start(
+        {CONST.TRIGGER.ZOCALO: CONST.PLAN.DO_FGS, "zocalo_environment": zocalo_env}  # type: ignore
+    )
     assert zocalo_cb.triggering_plan == CONST.PLAN.DO_FGS
-
-    mock_zocalo_trigger_class.return_value = (mock_zocalo_trigger := MagicMock())
 
     fake_fgs_composite.eiger.unstage = MagicMock()
     fake_fgs_composite.eiger.odin.file_writer.id.sim_put("test/filename")  # type: ignore
@@ -863,7 +862,6 @@ def test_kickoff_and_complete_gridscan_triggers_zocalo(
             fake_fgs_composite.zebra_fast_grid_scan,
             fake_fgs_composite.eiger,
             fake_fgs_composite.synchrotron,
-            zocalo_env,
             scan_points=create_dummy_scan_spec(x_steps, y_steps, z_steps),
             scan_start_indices=[0, x_steps * y_steps],
         )

--- a/tests/unit_tests/experiment_plans/test_multi_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_multi_rotation_scan_plan.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from hyperion.parameters.rotation import MultiRotationScan
+
+TEST_OFFSET = 1
+TEST_SHUTTER_OPENING_DEGREES = 2.5
+
+
+def test_multi_rotation_scan_params(test_multi_rotation_params: MultiRotationScan):
+    for scan in test_multi_rotation_params.single_rotation_scans:
+        assert isinstance(scan.omega_start_deg, float)

--- a/tests/unit_tests/experiment_plans/test_multi_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_multi_rotation_scan_plan.py
@@ -1,6 +1,18 @@
 from __future__ import annotations
 
+from itertools import takewhile
+
+from dodal.devices.synchrotron import SynchrotronMode
+from ophyd_async.core import set_mock_value
+
+from hyperion.experiment_plans.rotation_scan_plan import (
+    RotationScanComposite,
+    calculate_motion_profile,
+    multi_rotation_scan,
+)
 from hyperion.parameters.rotation import MultiRotationScan
+
+from ...conftest import RunEngineSimulator
 
 TEST_OFFSET = 1
 TEST_SHUTTER_OPENING_DEGREES = 2.5
@@ -9,3 +21,77 @@ TEST_SHUTTER_OPENING_DEGREES = 2.5
 def test_multi_rotation_scan_params(test_multi_rotation_params: MultiRotationScan):
     for scan in test_multi_rotation_params.single_rotation_scans:
         assert isinstance(scan.omega_start_deg, float)
+
+
+def test_multi_rotation_plan_runs_multiple_plans_in_one_arm(
+    fake_create_rotation_devices: RotationScanComposite,
+    test_multi_rotation_params: MultiRotationScan,
+    sim_run_engine_for_rotation: RunEngineSimulator,
+):
+    omega = fake_create_rotation_devices.smargon.omega
+    set_mock_value(
+        fake_create_rotation_devices.synchrotron.synchrotron_mode, SynchrotronMode.USER
+    )
+    msgs = sim_run_engine_for_rotation.simulate_plan(
+        multi_rotation_scan(fake_create_rotation_devices, test_multi_rotation_params)
+    )
+
+    msgs = sim_run_engine_for_rotation.assert_message_and_return_remaining(
+        msgs, lambda msg: msg.command == "stage" and msg.obj.name == "eiger"
+    )[1:]
+
+    msgs_within_arming = list(
+        takewhile(
+            lambda msg: msg.command != "unstage"
+            and (not msg.obj or msg.obj.name != "eiger"),
+            msgs,
+        )
+    )
+
+    def _assert_set_seq_and_return_remaining(remaining, name_value_pairs):
+        for name, value in name_value_pairs:
+            try:
+                remaining = (
+                    sim_run_engine_for_rotation.assert_message_and_return_remaining(
+                        remaining,
+                        lambda msg: msg.command == "set"
+                        and msg.obj.name == name
+                        and msg.args == (value,),
+                    )
+                )
+            except Exception as e:
+                raise Exception(f"Failed to find {name} being set to {value}") from e
+        return remaining
+
+    for scan in test_multi_rotation_params.single_rotation_scans:
+        motion_values = calculate_motion_profile(
+            scan, int(omega.acceleration.get()), int(omega.max_velocity.get())
+        )
+        msgs_within_arming = _assert_set_seq_and_return_remaining(
+            msgs_within_arming,
+            [
+                ("smargon_x", scan.x_start_um),
+                ("smargon_y", scan.y_start_um),
+                ("smargon_z", scan.z_start_um),
+                ("smargon_phi", scan.phi_start_deg),
+                ("smargon_chi", scan.chi_start_deg),
+            ],
+        )
+        msgs_within_arming = (
+            sim_run_engine_for_rotation.assert_message_and_return_remaining(
+                msgs_within_arming,
+                lambda msg: msg.command == "set" and msg.obj.name == "zebra-pc-arm",
+            )
+        )
+        msgs_within_arming = (
+            sim_run_engine_for_rotation.assert_message_and_return_remaining(
+                msgs_within_arming,
+                lambda msg: msg.command == "set"
+                and msg.obj.name == "smargon_omega"
+                and msg.args
+                == (
+                    (scan.scan_width_deg + motion_values.shutter_opening_deg)
+                    * motion_values.direction.multiplier,
+                ),
+            )
+        )

--- a/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
@@ -71,6 +71,7 @@ def motion_values(test_rotation_params: RotationScan):
         test_rotation_params,
         0.005,  # time for acceleration
         222,
+        test_rotation_params.exposure_time_s,
     )
 
 
@@ -136,6 +137,7 @@ def test_rotation_scan_calculations(test_rotation_params: RotationScan):
         test_rotation_params,
         0.005,  # time for acceleration
         224,
+        test_rotation_params.exposure_time_s,
     )
 
     assert motion_values.direction == "Negative"

--- a/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
@@ -71,7 +71,6 @@ def motion_values(test_rotation_params: RotationScan):
         test_rotation_params,
         0.005,  # time for acceleration
         222,
-        test_rotation_params.exposure_time_s,
     )
 
 
@@ -137,7 +136,6 @@ def test_rotation_scan_calculations(test_rotation_params: RotationScan):
         test_rotation_params,
         0.005,  # time for acceleration
         224,
-        test_rotation_params.exposure_time_s,
     )
 
     assert motion_values.direction == "Negative"

--- a/tests/unit_tests/external_interaction/callbacks/conftest.py
+++ b/tests/unit_tests/external_interaction/callbacks/conftest.py
@@ -70,6 +70,7 @@ class TestData:
     test_rotation_start_main_document = {
         "uid": "2093c941-ded1-42c4-ab74-ea99980fbbfd",
         "subplan_name": CONST.PLAN.ROTATION_MAIN,
+        "zocalo_environment": "dev_artemis",
     }
     test_gridscan_outer_start_document = {
         "uid": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
@@ -79,6 +80,7 @@ class TestData:
         "plan_type": "generator",
         "plan_name": CONST.PLAN.GRIDSCAN_OUTER,
         "subplan_name": CONST.PLAN.GRIDSCAN_OUTER,
+        "zocalo_environment": "dev_artemis",
         CONST.TRIGGER.ZOCALO: CONST.PLAN.DO_FGS,
         "hyperion_parameters": dummy_params().json(),
     }
@@ -120,7 +122,6 @@ class TestData:
         "plan_type": "generator",
         "plan_name": CONST.PLAN.GRIDSCAN_AND_MOVE,
         "subplan_name": CONST.PLAN.DO_FGS,
-        "zocalo_environment": "dev_artemis",
         "scan_points": create_dummy_scan_spec(10, 20, 30),
     }
     test_descriptor_document_oav_snapshot: EventDescriptor = {

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -99,6 +99,7 @@ def fake_rotation_scan(
             "subplan_name": CONST.PLAN.ROTATION_OUTER,
             "hyperion_parameters": params.json(),
             CONST.TRIGGER.ZOCALO: CONST.PLAN.ROTATION_MAIN,
+            "zocalo_environment": params.zocalo_environment,
         }
     )
     def plan():

--- a/tests/unit_tests/external_interaction/callbacks/test_zocalo_handler.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_zocalo_handler.py
@@ -24,13 +24,17 @@ EXPECTED_RUN_END_MESSAGE = {
 td = TestData()
 
 
+def start_dict(plan_name: str = "test_plan_name", env: str = "test_env"):
+    return {CONST.TRIGGER.ZOCALO: plan_name, "zocalo_environment": env}
+
+
 class TestZocaloHandler:
     def _setup_handler(self):
         zocalo_handler = ZocaloCallback()
         assert zocalo_handler.triggering_plan is None
-        zocalo_handler.start({CONST.TRIGGER.ZOCALO: "test_plan_name"})  # type: ignore
+        zocalo_handler.start(start_dict())  # type: ignore
         assert zocalo_handler.triggering_plan == "test_plan_name"
-        assert zocalo_handler.zocalo_interactor is None
+        assert zocalo_handler.zocalo_interactor is not None
         return zocalo_handler
 
     def test_handler_gets_plan_name_from_start_doc(self):
@@ -38,17 +42,15 @@ class TestZocaloHandler:
 
     def test_handler_doesnt_trigger_on_wrong_plan(self):
         zocalo_handler = self._setup_handler()
-        zocalo_handler.start({CONST.TRIGGER.ZOCALO: "_not_test_plan_name"})  # type: ignore
+        zocalo_handler.start(start_dict("_not_test_plan_name"))  # type: ignore
 
     def test_handler_raises_on_right_plan_with_wrong_metadata(self):
         zocalo_handler = self._setup_handler()
-        assert zocalo_handler.zocalo_interactor is None
         with pytest.raises(AssertionError):
             zocalo_handler.start({"subplan_name": "test_plan_name"})  # type: ignore
 
     def test_handler_raises_on_right_plan_with_no_ispyb_ids(self):
         zocalo_handler = self._setup_handler()
-        assert zocalo_handler.zocalo_interactor is None
         with pytest.raises(ISPyBDepositionNotMade):
             zocalo_handler.start(
                 {
@@ -64,7 +66,6 @@ class TestZocaloHandler:
     )
     def test_handler_inits_zocalo_trigger_on_right_plan(self, zocalo_trigger):
         zocalo_handler = self._setup_handler()
-        assert zocalo_handler.zocalo_interactor is None
         zocalo_handler.start(
             {
                 "subplan_name": "test_plan_name",


### PR DESCRIPTION
Part of #960
Separate PR from callback changes to make it easier to review

Link to dodal PR (if required): #[XXX](https://github.com/DiamondLightSource/dodal/pull/641)

Adds a parameter model for a multi rotation scan, rearranges some components of the rotation scan, and adds a plan to do multiple rotation scans

### To test:
1. inspect and run tests