### PR TITLE
Fix pre-commit hooks for new ruff syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         name: Run ruff
         stages: [commit]
         language: system
-        entry: ruff
+        entry: ruff check
         types: [python]
 
   # Syntax validation and some basic sanity checks


### PR DESCRIPTION
Fixes pre-commit hooks for the changed ruff syntax (as opposed to CI)

