### PR TITLE
Combine nexus and ispyb hardware readings and improve naming

### DIFF
--- a/src/hyperion/device_setup_plans/read_hardware_for_setup.py
+++ b/src/hyperion/device_setup_plans/read_hardware_for_setup.py
@@ -16,16 +16,16 @@ from hyperion.log import LOGGER
 from hyperion.parameters.constants import CONST
 
 
-def read_hardware_for_ispyb_pre_collection(
+def read_hardware_pre_collection(
     undulator: Undulator,
     synchrotron: Synchrotron,
     s4_slit_gaps: S4SlitGaps,
     robot: BartRobot,
     smargon: Smargon,
 ):
-    LOGGER.info("Reading status of beamline for ispyb deposition, pre collection.")
+    LOGGER.info("Reading status of beamline for callbacks, pre collection.")
     yield from bps.create(
-        name=CONST.DESCRIPTORS.ISPYB_HARDWARE_READ
+        name=CONST.DESCRIPTORS.HARDWARE_READ_PRE
     )  # gives name to event *descriptor* document
     yield from bps.read(undulator.current_gap)
     yield from bps.read(synchrotron.synchrotron_mode)
@@ -37,23 +37,19 @@ def read_hardware_for_ispyb_pre_collection(
     yield from bps.save()
 
 
-def read_hardware_for_ispyb_during_collection(
+def read_hardware_during_collection(
     aperture_scatterguard: ApertureScatterguard,
     attenuator: Attenuator,
     flux: Flux,
     dcm: DCM,
+    detector: EigerDetector,
 ):
-    LOGGER.info("Reading status of beamline for ispyb deposition, during collection.")
-    yield from bps.create(name=CONST.DESCRIPTORS.ISPYB_TRANSMISSION_FLUX_READ)
+    LOGGER.info("Reading status of beamline for callbacks, during collection.")
+    yield from bps.create(name=CONST.DESCRIPTORS.HARDWARE_READ_DURING)
     yield from bps.read(aperture_scatterguard)
     yield from bps.read(attenuator.actual_transmission)
     yield from bps.read(flux.flux_reading)
     yield from bps.read(dcm.energy_in_kev)
-    yield from bps.save()
-
-
-def read_hardware_for_nexus_writer(detector: EigerDetector):
-    yield from bps.create(name=CONST.DESCRIPTORS.NEXUS_READ)
     yield from bps.read(detector.bit_depth)
     yield from bps.save()
 

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -27,10 +27,9 @@ from hyperion.device_setup_plans.manipulate_sample import (
     setup_sample_environment,
 )
 from hyperion.device_setup_plans.read_hardware_for_setup import (
-    read_hardware_for_ispyb_during_collection,
-    read_hardware_for_ispyb_pre_collection,
-    read_hardware_for_nexus_writer,
+    read_hardware_during_collection,
     read_hardware_for_zocalo,
+    read_hardware_pre_collection,
 )
 from hyperion.device_setup_plans.setup_zebra import (
     arm_zebra,
@@ -214,15 +213,13 @@ def rotation_scan_plan(
         # get some information for the ispyb deposition and trigger the callback
         yield from read_hardware_for_zocalo(composite.eiger)
 
-        yield from read_hardware_for_ispyb_pre_collection(
+        yield from read_hardware_pre_collection(
             composite.undulator,
             composite.synchrotron,
             composite.s4_slit_gaps,
             composite.robot,
             composite.smargon,
         )
-
-        yield from read_hardware_for_nexus_writer(composite.eiger)
 
         # Get ready for the actual scan
         yield from bps.abs_set(
@@ -242,11 +239,12 @@ def rotation_scan_plan(
         LOGGER.info("Executing rotation scan")
         yield from bps.rel_set(axis, motion_values.distance_to_move_deg, wait=True)
 
-        yield from read_hardware_for_ispyb_during_collection(
+        yield from read_hardware_during_collection(
             composite.aperture_scatterguard,
             composite.attenuator,
             composite.flux,
             composite.dcm,
+            composite.eiger,
         )
 
     yield from _rotation_scan_plan(motion_values, composite)

--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -86,9 +86,9 @@ class BaseISPyBCallback(PlanReactiveCallback):
             )
             return doc
         match event_descriptor.get("name"):
-            case CONST.DESCRIPTORS.ISPYB_HARDWARE_READ:
+            case CONST.DESCRIPTORS.HARDWARE_READ_PRE:
                 scan_data_infos = self._handle_ispyb_hardware_read(doc)
-            case CONST.DESCRIPTORS.ISPYB_TRANSMISSION_FLUX_READ:
+            case CONST.DESCRIPTORS.HARDWARE_READ_DURING:
                 scan_data_infos = self._handle_ispyb_transmission_flux_read(doc)
             case _:
                 return self._tag_doc(doc)

--- a/src/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/nexus_callback.py
@@ -50,10 +50,7 @@ class RotationNexusFileCallback(PlanReactiveCallback):
                 "has no corresponding descriptor record"
             )
             return doc
-        if (
-            event_descriptor.get("name")
-            == CONST.DESCRIPTORS.ISPYB_TRANSMISSION_FLUX_READ
-        ):
+        if event_descriptor.get("name") == CONST.DESCRIPTORS.HARDWARE_READ_DURING:
             NEXUS_LOGGER.info(
                 f"Nexus handler received event from read hardware {format_doc_for_log(doc)}"
             )
@@ -67,12 +64,7 @@ class RotationNexusFileCallback(PlanReactiveCallback):
                 data["flux_flux_reading"],
                 data["attenuator-actual_transmission"],
             )
-        if event_descriptor.get("name") == CONST.DESCRIPTORS.NEXUS_READ:
-            NEXUS_LOGGER.info(
-                f"Nexus handler received event from read hardware {format_doc_for_log(doc)}"
-            )
             vds_data_type = vds_type_based_on_bit_depth(doc["data"]["eiger_bit_depth"])
-            assert self.writer is not None
             self.writer.create_nexus_file(vds_data_type)
             NEXUS_LOGGER.info(f"Nexus file created at {self.writer.full_filename}")
         return doc

--- a/src/hyperion/external_interaction/callbacks/xray_centre/nexus_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/nexus_callback.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict
 
-from hyperion.external_interaction.callbacks.logging_callback import format_doc_for_log
 from hyperion.external_interaction.callbacks.plan_reactive_callback import (
     PlanReactiveCallback,
 )
@@ -75,10 +74,7 @@ class GridscanNexusFileCallback(PlanReactiveCallback):
 
     def activity_gated_event(self, doc: Event) -> Event | None:
         assert (event_descriptor := self.descriptors.get(doc["descriptor"])) is not None
-        if (
-            event_descriptor.get("name")
-            == CONST.DESCRIPTORS.ISPYB_TRANSMISSION_FLUX_READ
-        ):
+        if event_descriptor.get("name") == CONST.DESCRIPTORS.HARDWARE_READ_DURING:
             data = doc["data"]
             for nexus_writer in [self.nexus_writer_1, self.nexus_writer_2]:
                 assert nexus_writer, "Nexus callback did not receive start doc"
@@ -90,15 +86,9 @@ class GridscanNexusFileCallback(PlanReactiveCallback):
                     data["flux_flux_reading"],
                     data["attenuator-actual_transmission"],
                 )
-        if event_descriptor.get("name") == CONST.DESCRIPTORS.NEXUS_READ:
-            NEXUS_LOGGER.info(
-                f"Nexus handler received event from read hardware {format_doc_for_log(doc)}"
-            )
-            for nexus_writer in [self.nexus_writer_1, self.nexus_writer_2]:
                 vds_data_type = vds_type_based_on_bit_depth(
                     doc["data"]["eiger_bit_depth"]
                 )
-                assert nexus_writer, "Nexus callback did not receive start doc"
                 nexus_writer.create_nexus_file(vds_data_type)
                 NEXUS_LOGGER.info(f"Nexus file created at {nexus_writer.full_filename}")
 

--- a/src/hyperion/parameters/constants.py
+++ b/src/hyperion/parameters/constants.py
@@ -48,9 +48,8 @@ class DocDescriptorNames:
     # For callbacks to use
     OAV_ROTATION_SNAPSHOT_TRIGGERED = "rotation_snapshot_triggered"
     OAV_GRID_SNAPSHOT_TRIGGERED = "snapshot_to_ispyb"
-    NEXUS_READ = "nexus_read_plan"
-    ISPYB_HARDWARE_READ = "ispyb_reading_hardware"
-    ISPYB_TRANSMISSION_FLUX_READ = "ispyb_update_transmission_flux"
+    HARDWARE_READ_PRE = "read_hardware_for_callbacks_pre_collection"
+    HARDWARE_READ_DURING = "read_hardware_for_callbacks_during_collection"
     ZOCALO_HW_READ = "zocalo_read_hardware_plan"
 
 

--- a/src/hyperion/utils/validation.py
+++ b/src/hyperion/utils/validation.py
@@ -11,8 +11,7 @@ from dodal.beamlines import i03
 from ophyd_async.core import set_mock_value
 
 from hyperion.device_setup_plans.read_hardware_for_setup import (
-    read_hardware_for_ispyb_during_collection,
-    read_hardware_for_nexus_writer,
+    read_hardware_during_collection,
 )
 from hyperion.experiment_plans.rotation_scan_plan import RotationScanComposite
 from hyperion.external_interaction.callbacks.rotation.nexus_callback import (
@@ -63,13 +62,13 @@ def fake_rotation_scan(
         }
     )
     def plan():
-        yield from read_hardware_for_ispyb_during_collection(
+        yield from read_hardware_during_collection(
             rotation_devices.aperture_scatterguard,
             rotation_devices.attenuator,
             rotation_devices.flux,
             rotation_devices.dcm,
+            rotation_devices.eiger,
         )
-        yield from read_hardware_for_nexus_writer(rotation_devices.eiger)
 
     return plan()
 

--- a/tests/system_tests/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/experiment_plans/test_fgs_plan.py
@@ -18,8 +18,8 @@ from ophyd.status import Status
 from ophyd_async.core import set_mock_value
 
 from hyperion.device_setup_plans.read_hardware_for_setup import (
-    read_hardware_for_ispyb_during_collection,
-    read_hardware_for_ispyb_pre_collection,
+    read_hardware_during_collection,
+    read_hardware_pre_collection,
 )
 from hyperion.device_setup_plans.xbpm_feedback import (
     transmission_and_xbpm_feedback_for_collection_decorator,
@@ -134,16 +134,16 @@ def test_s03_devices_connect(fxc_composite: FlyScanXRayCentreComposite):
 
 @pytest.mark.asyncio
 @pytest.mark.s03
-def test_read_hardware_for_ispyb_pre_collection(
+def test_read_hardware_pre_collection(
     RE: RunEngine,
     fxc_composite: FlyScanXRayCentreComposite,
 ):
     @bpp.run_decorator()
     def read_run(u, s, g, r, a, f, dcm, ap_sg, sm):
-        yield from read_hardware_for_ispyb_pre_collection(
+        yield from read_hardware_pre_collection(
             undulator=u, synchrotron=s, s4_slit_gaps=g, robot=r, smargon=sm
         )
-        yield from read_hardware_for_ispyb_during_collection(ap_sg, a, f, dcm)
+        yield from read_hardware_during_collection(ap_sg, a, f, dcm)
 
     RE(
         read_run(

--- a/tests/system_tests/experiment_plans/test_plan_system.py
+++ b/tests/system_tests/experiment_plans/test_plan_system.py
@@ -7,8 +7,8 @@ from dodal.devices.s4_slit_gaps import S4SlitGaps
 from dodal.devices.undulator import Undulator
 
 from hyperion.device_setup_plans.read_hardware_for_setup import (
-    read_hardware_for_ispyb_during_collection,
-    read_hardware_for_ispyb_pre_collection,
+    read_hardware_during_collection,
+    read_hardware_pre_collection,
 )
 from hyperion.parameters.constants import CONST
 
@@ -28,7 +28,7 @@ async def test_getting_data_for_ispyb():
         prefix=f"{CONST.SIM.BEAMLINE}-AL-APSG-04:", name="ao_sg"
     )
     smargon = i03.smargon(fake_with_ophyd_sim=True)
-
+    eiger = i03.eiger(fake_with_ophyd_sim=True)
     await undulator.connect()
     await synchrotron.connect()
     slit_gaps.wait_for_connection()
@@ -42,10 +42,8 @@ async def test_getting_data_for_ispyb():
 
     @bpp.run_decorator()
     def standalone_read_hardware(und, syn, slits, robot, att, flux, ap_sg, sm):
-        yield from read_hardware_for_ispyb_pre_collection(
-            und, syn, slits, robot, smargon=sm
-        )
-        yield from read_hardware_for_ispyb_during_collection(ap_sg, att, flux, dcm)
+        yield from read_hardware_pre_collection(und, syn, slits, robot, smargon=sm)
+        yield from read_hardware_during_collection(ap_sg, att, flux, dcm, eiger)
 
     RE(
         standalone_read_hardware(

--- a/tests/system_tests/external_interaction/test_nexgen.py
+++ b/tests/system_tests/external_interaction/test_nexgen.py
@@ -8,8 +8,7 @@ import pytest
 from bluesky.run_engine import RunEngine
 
 from hyperion.device_setup_plans.read_hardware_for_setup import (
-    read_hardware_for_ispyb_during_collection,
-    read_hardware_for_nexus_writer,
+    read_hardware_during_collection,
 )
 from hyperion.experiment_plans.rotation_scan_plan import RotationScanComposite
 from hyperion.external_interaction.callbacks.rotation.nexus_callback import (
@@ -161,12 +160,12 @@ def _fake_rotation_scan(
         }
     )
     def plan():
-        yield from read_hardware_for_ispyb_during_collection(
+        yield from read_hardware_during_collection(
             rotation_devices.aperture_scatterguard,
             rotation_devices.attenuator,
             rotation_devices.flux,
             rotation_devices.dcm,
+            rotation_devices.eiger,
         )
-        yield from read_hardware_for_nexus_writer(rotation_devices.eiger)
 
     return plan()

--- a/tests/unit_tests/experiment_plans/conftest.py
+++ b/tests/unit_tests/experiment_plans/conftest.py
@@ -83,7 +83,7 @@ def run_generic_ispyb_handler_setup(
         }  # type: ignore
     )
     ispyb_handler.activity_gated_descriptor(
-        {"uid": "123abc", "name": CONST.DESCRIPTORS.ISPYB_HARDWARE_READ}  # type: ignore
+        {"uid": "123abc", "name": CONST.DESCRIPTORS.HARDWARE_READ_PRE}  # type: ignore
     )
     ispyb_handler.activity_gated_event(
         make_event_doc(
@@ -92,7 +92,7 @@ def run_generic_ispyb_handler_setup(
         )
     )
     ispyb_handler.activity_gated_descriptor(
-        {"uid": "abc123", "name": CONST.DESCRIPTORS.ISPYB_TRANSMISSION_FLUX_READ}  # type: ignore
+        {"uid": "abc123", "name": CONST.DESCRIPTORS.HARDWARE_READ_DURING}  # type: ignore
     )
     ispyb_handler.activity_gated_event(
         make_event_doc(

--- a/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
+++ b/tests/unit_tests/experiment_plans/test_rotation_scan_plan.py
@@ -297,7 +297,7 @@ def test_rotation_plan_reads_hardware(
     msgs = sim_run_engine.assert_message_and_return_remaining(
         msgs,
         lambda msg: msg.command == "create"
-        and msg.kwargs["name"] == CONST.DESCRIPTORS.ISPYB_HARDWARE_READ,
+        and msg.kwargs["name"] == CONST.DESCRIPTORS.HARDWARE_READ_PRE,
     )
     msgs_in_event = list(takewhile(lambda msg: msg.command != "save", msgs))
     sim_run_engine.assert_message_and_return_remaining(

--- a/tests/unit_tests/external_interaction/callbacks/conftest.py
+++ b/tests/unit_tests/external_interaction/callbacks/conftest.py
@@ -142,22 +142,17 @@ class TestData:
     test_descriptor_document_pre_data_collection: EventDescriptor = {
         "uid": "bd45c2e5-2b85-4280-95d7-a9a15800a78b",
         "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-        "name": CONST.DESCRIPTORS.ISPYB_HARDWARE_READ,
+        "name": CONST.DESCRIPTORS.HARDWARE_READ_PRE,
     }  # type: ignore
     test_descriptor_document_during_data_collection: EventDescriptor = {
         "uid": "bd45c2e5-2b85-4280-95d7-a9a15800a78b",
         "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-        "name": CONST.DESCRIPTORS.ISPYB_TRANSMISSION_FLUX_READ,
+        "name": CONST.DESCRIPTORS.HARDWARE_READ_DURING,
     }  # type: ignore
     test_descriptor_document_zocalo_hardware: EventDescriptor = {
         "uid": "f082901b-7453-4150-8ae5-c5f98bb34406",
         "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
         "name": CONST.DESCRIPTORS.ZOCALO_HW_READ,
-    }  # type: ignore
-    test_descriptor_document_nexus_read: EventDescriptor = {
-        "uid": "aaaaaa",
-        "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-        "name": CONST.DESCRIPTORS.NEXUS_READ,
     }  # type: ignore
     test_event_document_oav_rotation_snapshot: Event = {
         "descriptor": "c7d698ce-6d49-4c56-967e-7d081f964573",
@@ -237,20 +232,16 @@ class TestData:
             "attenuator-actual_transmission": 1,
             "flux_flux_reading": 10,
             "dcm-energy_in_kev": 11.105,
+            "eiger_bit_depth": "16",
         },
-        "timestamps": {"det1": 1666604299.8220396, "det2": 1666604299.8235943},
+        "timestamps": {
+            "det1": 1666604299.8220396,
+            "det2": 1666604299.8235943,
+            "eiger_bit_depth": 1666604299.8220396,
+        },
         "seq_num": 1,
         "uid": "29033ecf-e052-43dd-98af-c7cdd62e8174",
         "filled": {},
-    }
-    test_event_document_nexus_read: Event = {
-        "uid": "29033ecf-e052-43dd-98af-c7cdd62e8175",
-        "time": 1709654583.9770422,
-        "data": {"eiger_bit_depth": "16"},
-        "timestamps": {"eiger_bit_depth": 1666604299.8220396},
-        "seq_num": 1,
-        "filled": {},
-        "descriptor": "aaaaaa",
     }
     test_event_document_zocalo_hardware: Event = {
         "uid": "29033ecf-e052-43dd-98af-c7cdd62e8175",

--- a/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
+++ b/tests/unit_tests/external_interaction/callbacks/test_rotation_callbacks.py
@@ -15,8 +15,7 @@ from ophyd.sim import make_fake_device
 from ophyd_async.core import DeviceCollector, set_mock_value
 
 from hyperion.device_setup_plans.read_hardware_for_setup import (
-    read_hardware_for_ispyb_during_collection,
-    read_hardware_for_nexus_writer,
+    read_hardware_during_collection,
     read_hardware_for_zocalo,
 )
 from hyperion.external_interaction.callbacks.common.callback_util import (
@@ -119,10 +118,9 @@ def fake_rotation_scan(
             }
         )
         def fake_main_plan():
-            yield from read_hardware_for_ispyb_during_collection(
-                ap_sg, attenuator, flux, dcm
+            yield from read_hardware_during_collection(
+                ap_sg, attenuator, flux, dcm, eiger
             )
-            yield from read_hardware_for_nexus_writer(eiger)
             yield from read_hardware_for_zocalo(eiger)
             if after_main_do:
                 after_main_do(subscriptions)
@@ -162,7 +160,7 @@ def test_nexus_handler_gets_documents_in_mock_plan(
     call_content_inner = nexus_handler.activity_gated_start.call_args_list[1].args[0]  # type: ignore
     assert call_content_inner["subplan_name"] == CONST.PLAN.ROTATION_MAIN
 
-    assert nexus_handler.activity_gated_event.call_count == 3  # type: ignore
+    assert nexus_handler.activity_gated_event.call_count == 2  # type: ignore
 
 
 @patch(

--- a/tests/unit_tests/external_interaction/callbacks/xray_centre/test_nexus_handler.py
+++ b/tests/unit_tests/external_interaction/callbacks/xray_centre/test_nexus_handler.py
@@ -28,7 +28,7 @@ def test_writers_not_sDTypeLikeetup_on_plan_start_doc(
 
 
 @patch("hyperion.external_interaction.callbacks.xray_centre.nexus_callback.NexusWriter")
-def test_writers_dont_create_on_init_but_do_on_nexus_read_event(
+def test_writers_dont_create_on_init_but_do_on_during_collection_read_event(
     mock_nexus_writer: MagicMock,
 ):
     mock_nexus_writer.side_effect = [MagicMock(), MagicMock()]
@@ -39,10 +39,12 @@ def test_writers_dont_create_on_init_but_do_on_nexus_read_event(
 
     nexus_handler.activity_gated_start(TestData.test_gridscan_outer_start_document)
     nexus_handler.activity_gated_descriptor(
-        TestData.test_descriptor_document_nexus_read
+        TestData.test_descriptor_document_during_data_collection
     )
 
-    nexus_handler.activity_gated_event(TestData.test_event_document_nexus_read)
+    nexus_handler.activity_gated_event(
+        TestData.test_event_document_during_data_collection
+    )
 
     assert nexus_handler.nexus_writer_1 is not None
     assert nexus_handler.nexus_writer_2 is not None
@@ -69,9 +71,9 @@ def test_given_different_bit_depths_then_writers_created_wth_correct_VDS_size(
 
     nexus_handler.activity_gated_start(TestData.test_start_document)
     nexus_handler.activity_gated_descriptor(
-        TestData.test_descriptor_document_nexus_read
+        TestData.test_descriptor_document_during_data_collection
     )
-    event_doc = deepcopy(TestData.test_event_document_nexus_read)
+    event_doc = deepcopy(TestData.test_event_document_during_data_collection)
     event_doc["data"]["eiger_bit_depth"] = bit_depth
 
     nexus_handler.activity_gated_event(event_doc)

--- a/tests/unit_tests/external_interaction/test_write_rotation_nexus.py
+++ b/tests/unit_tests/external_interaction/test_write_rotation_nexus.py
@@ -11,8 +11,7 @@ from bluesky.run_engine import RunEngine
 from h5py import Dataset, ExternalLink, Group
 
 from hyperion.device_setup_plans.read_hardware_for_setup import (
-    read_hardware_for_ispyb_during_collection,
-    read_hardware_for_nexus_writer,
+    read_hardware_during_collection,
 )
 from hyperion.experiment_plans.rotation_scan_plan import RotationScanComposite
 from hyperion.external_interaction.callbacks.rotation.nexus_callback import (
@@ -62,13 +61,13 @@ def fake_rotation_scan(
         }
     )
     def plan():
-        yield from read_hardware_for_ispyb_during_collection(
+        yield from read_hardware_during_collection(
             rotation_devices.aperture_scatterguard,
             rotation_devices.attenuator,
             rotation_devices.flux,
             rotation_devices.dcm,
+            rotation_devices.eiger,
         )
-        yield from read_hardware_for_nexus_writer(rotation_devices.eiger)
 
     return plan()
 


### PR DESCRIPTION
Fixes #1482 

- Combines "read hardware for nexus" into the reading during the plan
- Removes "ispyb" from plan stub names, to make them just "read pre/during collection"

### To test:
1. Run tests