### PR TITLE
(#842) Fix ispyb activation so that messages can be logged from pin tip detection

### DIFF
--- a/src/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/grid_detect_then_xray_centre_plan.py
@@ -109,16 +109,6 @@ def detect_grid_and_do_gridscan(
     parameters: GridScanWithEdgeDetect,
     oav_params: OAVParameters,
 ):
-    yield from ispyb_activation_wrapper(
-        _detect_grid_and_do_gridscan(composite, parameters, oav_params), parameters
-    )
-
-
-def _detect_grid_and_do_gridscan(
-    composite: GridDetectThenXRayCentreComposite,
-    parameters: GridScanWithEdgeDetect,
-    oav_params: OAVParameters,
-):
     assert composite.aperture_scatterguard.aperture_positions is not None
 
     snapshot_template = f"{parameters.detector_params.prefix}_{parameters.detector_params.run_number}_{{angle}}"
@@ -202,10 +192,13 @@ def grid_detect_then_xray_centre(
 
     oav_params = OAVParameters("xrayCentring", oav_config)
 
-    plan_to_perform = detect_grid_and_do_gridscan(
-        composite,
+    plan_to_perform = ispyb_activation_wrapper(
+        detect_grid_and_do_gridscan(
+            composite,
+            parameters,
+            oav_params,
+        ),
         parameters,
-        oav_params,
     )
 
     return start_preparing_data_collection_then_do_plan(

--- a/src/hyperion/experiment_plans/pin_centre_then_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/pin_centre_then_xray_centre_plan.py
@@ -17,6 +17,9 @@ from hyperion.experiment_plans.pin_tip_centring_plan import (
     PinTipCentringComposite,
     pin_tip_centre_plan,
 )
+from hyperion.external_interaction.callbacks.xray_centre.ispyb_callback import (
+    ispyb_activation_wrapper,
+)
 from hyperion.log import LOGGER
 from hyperion.parameters.constants import CONST
 from hyperion.parameters.gridscan import (
@@ -61,21 +64,24 @@ def pin_centre_then_xray_centre_plan(
         pin_tip_detection=composite.pin_tip_detection,
     )
 
-    yield from pin_tip_centre_plan(
-        pin_tip_centring_composite,
-        parameters.tip_offset_um,
-        oav_config_file,
-    )
+    def _pin_centre_then_xray_centre_plan():
+        yield from pin_tip_centre_plan(
+            pin_tip_centring_composite,
+            parameters.tip_offset_um,
+            oav_config_file,
+        )
 
-    grid_detect_params = create_parameters_for_grid_detection(parameters)
+        grid_detect_params = create_parameters_for_grid_detection(parameters)
 
-    oav_params = OAVParameters("xrayCentring", oav_config_file)
+        oav_params = OAVParameters("xrayCentring", oav_config_file)
 
-    yield from detect_grid_and_do_gridscan(
-        composite,
-        grid_detect_params,
-        oav_params,
-    )
+        yield from detect_grid_and_do_gridscan(
+            composite,
+            grid_detect_params,
+            oav_params,
+        )
+
+    yield from ispyb_activation_wrapper(_pin_centre_then_xray_centre_plan(), parameters)
 
 
 def pin_tip_centre_then_xray_centre(

--- a/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
+++ b/tests/system_tests/external_interaction/test_ispyb_dev_connection.py
@@ -784,7 +784,7 @@ def test_ispyb_deposition_in_rotation_plan(
     assert dcid is not None
     assert (
         fetch_comment(dcid)
-        == "Sample position: (1.0, 2.0, 3.0) test  Aperture: Small. "
+        == "Sample position (µm): (1000, 2000, 3000) test  Aperture: Small. "
     )
 
     expected_values = EXPECTED_DATACOLLECTION_FOR_ROTATION | {

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -2,6 +2,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from event_model import Event, EventDescriptor
+
+from hyperion.parameters.constants import CONST
 
 BANNED_PATHS = [Path("/dls"), Path("/dls_sw")]
 
@@ -21,3 +24,57 @@ def patch_open_to_prevent_dls_reads_in_tests():
 
     with patch("builtins.open", side_effect=patched_open):
         yield []
+
+
+class OavGridSnapshotTestEvents:
+    test_descriptor_document_oav_snapshot: EventDescriptor = {
+        "uid": "b5ba4aec-de49-4970-81a4-b4a847391d34",
+        "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
+        "name": CONST.DESCRIPTORS.OAV_GRID_SNAPSHOT_TRIGGERED,
+    }  # type: ignore
+    test_event_document_oav_snapshot_xy: Event = {
+        "descriptor": "b5ba4aec-de49-4970-81a4-b4a847391d34",
+        "time": 1666604299.828203,
+        "timestamps": {},
+        "seq_num": 1,
+        "uid": "29033ecf-e052-43dd-98af-c7cdd62e8174",
+        "data": {
+            "oav_grid_snapshot_top_left_x": 50,
+            "oav_grid_snapshot_top_left_y": 100,
+            "oav_grid_snapshot_num_boxes_x": 40,
+            "oav_grid_snapshot_num_boxes_y": 20,
+            "oav_grid_snapshot_microns_per_pixel_x": 1.25,
+            "oav_grid_snapshot_microns_per_pixel_y": 1.5,
+            "oav_grid_snapshot_box_width": 0.1 * 1000 / 1.25,  # size in pixels
+            "oav_grid_snapshot_last_path_full_overlay": "test_1_y",
+            "oav_grid_snapshot_last_path_outer": "test_2_y",
+            "oav_grid_snapshot_last_saved_path": "test_3_y",
+            "smargon-omega": 0,
+            "smargon-x": 0,
+            "smargon-y": 0,
+            "smargon-z": 0,
+        },
+    }
+    test_event_document_oav_snapshot_xz: Event = {
+        "descriptor": "b5ba4aec-de49-4970-81a4-b4a847391d34",
+        "time": 1666604299.828203,
+        "timestamps": {},
+        "seq_num": 1,
+        "uid": "29033ecf-e052-43dd-98af-c7cdd62e8174",
+        "data": {
+            "oav_grid_snapshot_top_left_x": 50,
+            "oav_grid_snapshot_top_left_y": 0,
+            "oav_grid_snapshot_num_boxes_x": 40,
+            "oav_grid_snapshot_num_boxes_y": 10,
+            "oav_grid_snapshot_box_width": 0.1 * 1000 / 1.25,  # size in pixels
+            "oav_grid_snapshot_last_path_full_overlay": "test_1_z",
+            "oav_grid_snapshot_last_path_outer": "test_2_z",
+            "oav_grid_snapshot_last_saved_path": "test_3_z",
+            "oav_grid_snapshot_microns_per_pixel_x": 1.25,
+            "oav_grid_snapshot_microns_per_pixel_y": 1.5,
+            "smargon-omega": -90,
+            "smargon-x": 0,
+            "smargon-y": 0,
+            "smargon-z": 0,
+        },
+    }

--- a/tests/unit_tests/external_interaction/callbacks/conftest.py
+++ b/tests/unit_tests/external_interaction/callbacks/conftest.py
@@ -8,6 +8,7 @@ from hyperion.parameters.gridscan import ThreeDGridScan
 from tests.conftest import create_dummy_scan_spec
 
 from ....conftest import default_raw_params, raw_params_from_file
+from ...conftest import OavGridSnapshotTestEvents
 
 
 def dummy_params():
@@ -32,7 +33,7 @@ def test_rotation_start_outer_document(dummy_rotation_params):
     }
 
 
-class TestData:
+class TestData(OavGridSnapshotTestEvents):
     DUMMY_TIME_STRING: str = "1970-01-01 00:00:00"
     GOOD_ISPYB_RUN_STATUS: str = "DataCollection Successful"
     BAD_ISPYB_RUN_STATUS: str = "DataCollection Unsuccessful"
@@ -129,11 +130,6 @@ class TestData:
         "zocalo_environment": "dev_artemis",
         "scan_points": create_dummy_scan_spec(10, 20, 30),
     }
-    test_descriptor_document_oav_snapshot: EventDescriptor = {
-        "uid": "b5ba4aec-de49-4970-81a4-b4a847391d34",
-        "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-        "name": CONST.DESCRIPTORS.OAV_GRID_SNAPSHOT_TRIGGERED,
-    }  # type: ignore
     test_descriptor_document_oav_rotation_snapshot: EventDescriptor = {
         "uid": "c7d698ce-6d49-4c56-967e-7d081f964573",
         "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
@@ -161,46 +157,6 @@ class TestData:
         "seq_num": 1,
         "uid": "32d7c25c-c310-4292-ac78-36ce6509be3d",
         "data": {"oav_snapshot_last_saved_path": "snapshot_0"},
-    }
-    test_event_document_oav_snapshot_xy: Event = {
-        "descriptor": "b5ba4aec-de49-4970-81a4-b4a847391d34",
-        "time": 1666604299.828203,
-        "timestamps": {},
-        "seq_num": 1,
-        "uid": "29033ecf-e052-43dd-98af-c7cdd62e8174",
-        "data": {
-            "oav_grid_snapshot_top_left_x": 50,
-            "oav_grid_snapshot_top_left_y": 100,
-            "oav_grid_snapshot_num_boxes_x": 40,
-            "oav_grid_snapshot_num_boxes_y": 20,
-            "oav_grid_snapshot_microns_per_pixel_x": 1.25,
-            "oav_grid_snapshot_microns_per_pixel_y": 1.5,
-            "oav_grid_snapshot_box_width": 0.1 * 1000 / 1.25,  # size in pixels
-            "oav_grid_snapshot_last_path_full_overlay": "test_1_y",
-            "oav_grid_snapshot_last_path_outer": "test_2_y",
-            "oav_grid_snapshot_last_saved_path": "test_3_y",
-            "smargon-omega": 0,
-        },
-    }
-    test_event_document_oav_snapshot_xz: Event = {
-        "descriptor": "b5ba4aec-de49-4970-81a4-b4a847391d34",
-        "time": 1666604299.828203,
-        "timestamps": {},
-        "seq_num": 1,
-        "uid": "29033ecf-e052-43dd-98af-c7cdd62e8174",
-        "data": {
-            "oav_grid_snapshot_top_left_x": 50,
-            "oav_grid_snapshot_top_left_y": 0,
-            "oav_grid_snapshot_num_boxes_x": 40,
-            "oav_grid_snapshot_num_boxes_y": 10,
-            "oav_grid_snapshot_box_width": 0.1 * 1000 / 1.25,  # size in pixels
-            "oav_grid_snapshot_last_path_full_overlay": "test_1_z",
-            "oav_grid_snapshot_last_path_outer": "test_2_z",
-            "oav_grid_snapshot_last_saved_path": "test_3_z",
-            "oav_grid_snapshot_microns_per_pixel_x": 1.25,
-            "oav_grid_snapshot_microns_per_pixel_y": 1.5,
-            "smargon-omega": -90,
-        },
     }
     test_event_document_pre_data_collection: Event = {
         "descriptor": "bd45c2e5-2b85-4280-95d7-a9a15800a78b",


### PR DESCRIPTION
Fixes #824

Link to dodal PR (if required): N/A
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. ispyb comments should now appear when the pin tip is too short or too long
2. Tests pass
