### PR TITLE
Wrap async behaviour of updating directory_provider

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a4
     blueapi >= 0.4.3-rc1
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@fff4a4e8fdcf534de6768c2b45a0dfa7a2e2ccc4
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@3c2a002562659eea342e770e967678acd0e9ddfa
 
 [options.entry_points]
 console_scripts =

--- a/src/hyperion/device_setup_plans/setup_panda.py
+++ b/src/hyperion/device_setup_plans/setup_panda.py
@@ -204,7 +204,7 @@ def disarm_panda_for_gridscan(panda, group="disarm_panda_gridscan") -> MsgGenera
     yield from bps.wait(group=group, timeout=GENERAL_TIMEOUT)
 
 
-def set_and_create_panda_directory(panda_directory: Path):
+def set_and_create_panda_directory(panda_directory: Path) -> MsgGenerator:
     """Updates and creates the panda subdirectory which is used by the PandA's PCAP.
     See https://github.com/DiamondLightSource/hyperion/issues/1385 for a better long
     term solution.
@@ -215,4 +215,7 @@ def set_and_create_panda_directory(panda_directory: Path):
         # Assumes we have permissions, which should be true on Hyperion for now
         os.makedirs(panda_directory)
 
-    get_directory_provider().update(directory=panda_directory)
+    async def set_panda_dir():
+        get_directory_provider().update(directory=panda_directory)
+
+    yield from bps.wait_for([set_panda_dir])

--- a/src/hyperion/device_setup_plans/setup_panda.py
+++ b/src/hyperion/device_setup_plans/setup_panda.py
@@ -216,6 +216,6 @@ def set_and_create_panda_directory(panda_directory: Path) -> MsgGenerator:
         os.makedirs(panda_directory)
 
     async def set_panda_dir():
-        get_directory_provider().update(directory=panda_directory)
+        await get_directory_provider().update(directory=panda_directory)
 
     yield from bps.wait_for([set_panda_dir])

--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -525,7 +525,7 @@ def _panda_triggering_setup(
 
     panda_directory = Path(parameters.storage_directory, "panda")
 
-    set_and_create_panda_directory(panda_directory)
+    yield from set_and_create_panda_directory(panda_directory)
 
     yield from setup_panda_for_flyscan(
         fgs_composite.panda,

--- a/tests/unit_tests/device_setup_plans/test_setup_panda.py
+++ b/tests/unit_tests/device_setup_plans/test_setup_panda.py
@@ -178,7 +178,9 @@ def test_wait_between_setting_table_and_arming_panda(RE: RunEngine):
     ), patch(
         "hyperion.device_setup_plans.setup_panda.bps.wait",
         MagicMock(side_effect=handle_wait),
-    ), patch("hyperion.device_setup_plans.setup_panda.load_device"), patch(
+    ), patch(
+        "hyperion.device_setup_plans.setup_panda.load_device"
+    ), patch(
         "hyperion.device_setup_plans.setup_panda.bps.abs_set"
     ):
         RE(
@@ -204,15 +206,15 @@ def test_disarm_panda_disables_correct_blocks(sim_run_engine):
     assert num_of_waits == 1
 
 
-def test_set_and_create_panda_directory(tmp_path):
+def test_set_and_create_panda_directory(tmp_path, RE):
     with patch(
         "hyperion.device_setup_plans.setup_panda.os.path.isdir", return_value=False
     ), patch("hyperion.device_setup_plans.setup_panda.os.makedirs") as mock_makedir:
-        set_and_create_panda_directory(Path(tmp_path))
+        RE(set_and_create_panda_directory(Path(tmp_path)))
         mock_makedir.assert_called_once()
 
     with patch(
         "hyperion.device_setup_plans.setup_panda.os.path.isdir", return_value=True
     ), patch("hyperion.device_setup_plans.setup_panda.os.makedirs") as mock_makedir:
-        set_and_create_panda_directory(Path(tmp_path))
+        RE(set_and_create_panda_directory(Path(tmp_path)))
         mock_makedir.assert_not_called()


### PR DESCRIPTION
Fixes the directory provider update method being made asynchronous for dodal type checking

Link to dodal PR (if required): [#719](https://github.com/DiamondLightSource/dodal/pull/719), [#718](https://github.com/DiamondLightSource/dodal/pull/718)
(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
1. Confirm that PandA writes to correct directory
2. Confirm that setting output directory is blocking
