### PR TITLE
Changes to containerise hyperion and enable deployment to kubernetes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# List of folders and files to be excluded from the docker image
+.github
+.pytest_cache
+.ruff_cache
+
+# virtualenv stuff - this gets built by the docker script
+.venv
+activate
+
+tmp

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,0 +1,47 @@
+name: Publish Docker Image
+on:
+  release:
+    types: [published]
+  # Allow the workflow to be triggered manually
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build_and_push_image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        # v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Log in to GHCR
+        # v3.3.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        # v5.5.1
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        # v6.5.0
+        uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        # v1.4.0
+        uses: actions/attest-build-provenance@210c1913531870065f03ce1f9440dd87bc0938cd
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ MANIFEST
 *.manifest
 *.spec
 
+# Package version
+_version.py
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
       - id: check-ast
       - id: check-yaml
         args: ["--allow-multiple-documents"]
+        exclude: ^helmchart/
       - id: check-merge-conflict
       - id: check-added-large-files
         args: ["--maxkb=500"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,7 @@ ADD . /project/
 WORKDIR "/project"
 RUN pip install -e .[dev]
 RUN python -m build
+
+ENTRYPOINT /project/utility_scripts/docker/entrypoint.sh
+
+EXPOSE 5005

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,45 @@
+Building the Docker image
+====
+
+If you run into issues with `podman build .` failing with the error message
+`io: read/write on closed pipe` then you may be running out of disk space - try setting TMPDIR environment variable
+
+https://github.com/containers/podman/issues/22342
+
+### Building image on ubuntu
+
+If you run into issues such as 
+```commandline
+potentially insufficient UIDs or GIDs available in user namespace (requested 0:42 for /etc/gshadow): Check /etc/subuid and /etc/subgid: lchown /etc/gshadow: invalid argument
+```
+
+* Ensure newuidmap is installed
+`sudo apt-get install uidmap`
+* Add appropriate entries to `/etc/subuid` and `/etc/subgid`
+e.g.
+```
+# subuid/subgid file
+myuser:10000000:65536
+
+# subuid/subgid file
+myuser:10000000:65536
+```
+* kill any existing podman processes and retry
+
+For further information, see https://github.com/containers/podman/issues/2542
+
+Pushing the docker image
+===
+
+If building a release image, the image should be pushed to github by the release CI scripts _TODO_
+
+If building a test image, the image should be pushed to your personal GH account:
+
+`cat <mysecretfile> | podman login ghcr.io --username <your gh login> --password-stdin`
+ 
+`podman push ghcr.io/<your gh login>/`
+
+Deploying to kubernetes
+===
+
+Once the docker image is built, the image can be deployed to kubernetes using the `deploy_to_k8s.sh` script

--- a/helmchart/Chart.yaml
+++ b/helmchart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: hyperion
+description: Hyperion server
+type: application
+# version of the chart
+version: 0.0.1

--- a/helmchart/templates/deployment.yaml
+++ b/helmchart/templates/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyperion-deployment
+spec:
+  selector:
+    matchLabels:
+      app: hyperion
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: hyperion
+    spec:
+      securityContext:
+        # gda2
+        runAsUser: {{  .Values.hyperion.runAsUser }}
+        runAsGroup: {{ .Values.hyperion.runAsGroup }}
+        supplementalGroups: {{ .Values.hyperion.supplementalGroups }}
+      volumes:
+        - name: dls-sw-bl
+          hostPath:
+            path: "/dls_sw/{{ .Values.hyperion.beamline }}"
+            type: Directory
+        - name: dls-sw-apps
+          hostPath:
+            path: "/dls_sw/apps"
+            type: Directory
+        - name: dls-sw-dasc
+          hostPath:
+            path: "/dls_sw/dasc"
+            type: Directory
+        {{- if .Values.hyperion.dev }}
+        # Bind some source folders for easier debugging        
+        - name: src
+          hostPath:
+            path: "{{ .Values.hyperion.projectDir }}/src"
+            type: Directory
+        - name: tests
+          hostPath:
+            path: "{{ .Values.hyperion.projectDir }}/tests"
+            type: Directory
+        - name: utility-scripts
+          hostPath:
+            path: "{{ .Values.hyperion.projectDir }}/utility_scripts"
+            type: Directory
+        - name: devlogs
+          hostPath:
+            path: "{{ .Values.hyperion.projectDir }}/tmp"
+            type: Directory
+        {{- end }}
+      containers:
+      - name: hyperion
+        image: {{ .Values.hyperion.imageRepository}}/hyperion:latest
+        resources:
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        ports:
+          - name: hyperion-api
+            containerPort: 5005
+            protocol: TCP
+        env:
+          - name: HYPERION_LOG_DIR
+            value: {{ .Values.hyperion.logDir }}
+          - name: BEAMLINE
+            value: "{{ .Values.hyperion.beamline }}"
+          {{- if not .Values.hyperion.dev }}
+          - name: ZOCALO_GO_USER
+            value: "gda2"
+          - name: ZOCALO_GO_HOSTNAME
+            value: "{{ .Values.hyperion.beamline }}-control"
+          - name: ZOCALO_CONFIG
+            value: "/dls_sw/apps/zocalo/live/configuration.yaml"
+          - name: ISPYB_CONFIG_PATH
+            value: "/dls_sw/dasc/mariadb/credentials/ispyb-hyperion-{{ .Values.hyperion.beamline }}.cfg"
+        args: [ "--external-callbacks" ]
+          {{- end }}
+        readinessProbe:
+          exec:
+            command: [ "/project/docker/healthcheck.sh" ]
+          periodSeconds: 5
+        volumeMounts:
+          - mountPath: "/dls_sw/{{ .Values.hyperion.beamline }}"
+            name: dls-sw-bl
+            readOnly: true
+            mountPropagation: HostToContainer
+          - mountPath: "/dls_sw/apps"
+            name: dls-sw-apps
+            readOnly: true
+            mountPropagation: HostToContainer
+          - mountPath: "/dls_sw/dasc"
+            name: dls-sw-dasc
+            readOnly: true
+            mountPropagation: HostToContainer
+          {{- if .Values.hyperion.dev }}
+          - mountPath: "/project/src"
+            name: src
+          - mountPath: "/project/tests"
+            name: tests
+          - mountPath: "/project/utility_scripts"
+            name: utility-scripts
+          - mountPath: "/project/tmp"
+            name: devlogs
+          {{ end }}

--- a/helmchart/templates/service.yaml
+++ b/helmchart/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyperion-svc
+spec:
+  type: LoadBalancer
+  ports:
+    - name: hyperion-api
+      port: 5005
+      protocol: TCP
+      targetPort: 5005
+  selector:
+    app: hyperion

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -1,0 +1,10 @@
+hyperion:
+  imageRepository: ghcr.io/DiamondLightSource
+  runAsUser: 37500
+  runAsGroup: 37500
+  supplementalGroups: []
+  beamline: i03
+  dev: false
+  logDir: "/dls_sw/i03/logs/bluesky"
+service:
+  type: NodePort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-requires = ["setuptools<57", "wheel==0.33.1"]
+requires = ["setuptools<57", "wheel==0.33.1", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
+
+[project]
+dynamic = ["version"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
@@ -23,3 +26,6 @@ lint.select = [
     "W",    # pycodestyle warnings - https://beta.ruff.rs/docs/rules/#warning-w
     "I001", # isort
 ]
+
+[tool.setuptools_scm]
+write_to = "src/hyperion/_version.py"

--- a/run_in_podman.sh
+++ b/run_in_podman.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+STOP=0
+START=0
+UP=0
+IN_DEV=false
+
+for option in "$@"; do
+    case $option in
+        -b=*|--beamline=*)
+            BEAMLINE="${option#*=}"
+            shift
+            ;;
+        --stop)
+            STOP=1
+            ;;
+        --start)
+            START=1
+            ;;
+        --up)
+            UP=1
+            START=0
+            ;;
+        --logs)
+          LOGS=1
+          ;;
+        --restart)
+            STOP=1
+            START=1
+            ;;
+        --dev)
+            IN_DEV=true
+            ;;
+
+        --help|--info|--h)
+            echo "  --dev                 Use dev options, such as local graylog instances and S03"
+            echo "  -b, --beamline=BEAMLINE Overrides the BEAMLINE environment variable with the given beamline"
+            echo " "
+            echo "Operations"
+            echo "  --stop                  Used to stop a currently running instance of Hyperion. Will override any other operations"
+            echo "                          options"
+            echo "  --start                 Specify that the script should start the server"
+            echo "  --up                    Create the container for the service but do not start"
+            echo "  --restart               Specify that the script should stop and then start the server."
+            exit 0
+            ;;
+        -*|--*)
+            echo "Unknown option ${option}. Use --help for info on option usage."
+            exit 1
+            ;;
+    esac
+done
+
+kill_active_apps () {
+    echo "Killing active instances of hyperion and hyperion-callbacks..."
+    podman compose -f ${COMPOSE_YAML} stop ${SERVICE}
+    echo "done."
+}
+
+check_user () {
+    if [[ $HOSTNAME != "${BEAMLINE}-control.diamond.ac.uk" || $USER != "gda2" ]]; then
+        echo "Must be run from beamline control machine as gda2"
+        echo "Current host is $HOSTNAME and user is $USER"
+        exit 1
+    fi
+}
+
+RELATIVE_SCRIPT_DIR=$( dirname -- "$0"; )
+
+COMPOSE_YAML=${RELATIVE_SCRIPT_DIR}/utility_scripts/docker/${BEAMLINE}-compose.yml
+EXTRA_ARGS=""
+
+if [[ -z "${BEAMLINE}" ]]; then
+    echo "BEAMLINE parameter not set."
+    echo "If you would like to run on a dev machine set the option -b, --beamline=BEAMLNE to set it manually"
+    exit 1
+fi
+
+if [[ $IN_DEV == false ]]; then
+  SERVICE=hyperion
+else
+  if [[ $UP == 1 ]]; then
+    echo "--up cannot be used with --dev"
+    exit 1
+  fi
+  SERVICE=hyperion-dev
+fi
+
+if [[ $LOGS == 1 ]]; then
+  podman compose -f ${COMPOSE_YAML} logs ${SERVICE}
+  exit 0 
+fi
+
+if [[ $STOP == 1 ]]; then
+    if [[ $IN_DEV == false ]]; then
+        check_user
+    fi
+    kill_active_apps
+
+    echo "Hyperion stopped"
+fi
+
+if [[ $UP == 1 ]]; then
+  podman compose -f ${COMPOSE_YAML} down --remove-orphans
+  podman compose -f ${COMPOSE_YAML} up --no-start --no-build ${SERVICE}
+fi
+
+if [[ $START == 1 ]]; then
+    if [ $IN_DEV == false ]; then
+        check_user
+    fi
+
+    kill_active_apps
+
+    if [[ $IN_DEV == true ]]; then
+      echo "Starting with podman compose -f ${COMPOSE_YAML} run -v ${HOME}/.zocalo:/root/.zocalo ${SERVICE}"
+      podman compose -f ${COMPOSE_YAML} run -v ${HOME}/.zocalo:/root/.zocalo ${SERVICE}
+    else
+      echo "Starting with podman compose -f ${COMPOSE_YAML} start ${SERVICE}"
+      podman compose -f ${COMPOSE_YAML} start ${SERVICE}
+    fi
+fi

--- a/src/hyperion/__main__.py
+++ b/src/hyperion/__main__.py
@@ -275,9 +275,7 @@ class StopOrStatus(Resource):
         action = kwargs.get("action")
         status_and_message = StatusAndMessage(Status.FAILED, f"{action} not understood")
         if action == Actions.STATUS.value:
-            LOGGER.debug(
-                f"Runner recieved status request - state of the runner object is: {self.runner.__dict__} - state of the RE is: {self.runner.RE.__dict__}"
-            )
+            LOGGER.debug("Runner recieved status request")
             status_and_message = self.runner.current_status
         return asdict(status_and_message)
 

--- a/src/hyperion/parameters/cli.py
+++ b/src/hyperion/parameters/cli.py
@@ -2,6 +2,8 @@ import argparse
 
 from pydantic.dataclasses import dataclass
 
+from hyperion._version import version
+
 
 @dataclass
 class HyperionArgs:
@@ -50,6 +52,12 @@ def parse_cli_args() -> HyperionArgs:
         "--external-callbacks",
         action="store_true",
         help="Run the external hyperion-callbacks service and publish events over ZMQ",
+    )
+    parser.add_argument(
+        "--version",
+        help="Print hyperion version string",
+        action="version",
+        version=version
     )
     args = parser.parse_args()
     return HyperionArgs(

--- a/utility_scripts/build_docker_image.sh
+++ b/utility_scripts/build_docker_image.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# builds the docker image
+BUILD=1
+PUSH=1
+for option in "$@"; do
+    case $option in
+        --no-build)
+            BUILD=0
+            shift
+            ;;
+        --no-push)
+            PUSH=0
+            shift
+            ;;
+        --help|--info|--h)
+            CMD=`basename $0`
+            echo "$CMD [options"
+            echo "Builds and/or pushes the docker container image to the repository"
+            echo "  --help                  This help"
+            echo "  --no-build              Do not build the image"
+            echo "  --no-push               Do not push the image"
+            exit 0
+            ;;
+        -*|--*)
+            echo "Unknown option ${option}. Use --help for info on option usage."
+            exit 1
+            ;;
+    esac
+done
+
+PROJECTDIR=`dirname $0`/..
+VERSION=$1
+if [ -z $VERSION ]; then
+  VERSION=`hyperion --version | sed -e 's/[^a-zA-Z0-9._-]/_/g'`
+fi
+PROJECT=hyperion
+TAG=$PROJECT:$VERSION
+LATEST_TAG=$PROJECT:latest
+
+if [[ $BUILD == 1 ]]; then
+  echo "podman build --tag $TAG --tag $LATEST_TAG $PROJECTDIR"
+  TMPDIR=/tmp podman build --tag $TAG --tag $LATEST_TAG $PROJECTDIR
+fi
+
+if [[ $PUSH == 1 ]]; then
+  NAMESPACE=`podman login --get-login ghcr.io`
+  if [[ $? != 0 ]]; then
+    echo "Not logged in to ghcr.io"
+    exit 1
+  fi
+  echo "Pushing to ghcr.io/$NAMESPACE/$PROJECT:latest ..."
+  podman push $PROJECT:latest ghcr.io/$NAMESPACE/$PROJECT:latest
+fi

--- a/utility_scripts/deploy/deploy_to_k8s.sh
+++ b/utility_scripts/deploy/deploy_to_k8s.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Installs helm package to kubernetes
+for option in "$@"; do
+    case $option in
+        -b=*|--beamline=*)
+            BEAMLINE="${option#*=}"
+            shift
+            ;;
+        --dev)
+            DEV=true
+            shift
+            ;;
+        --repository=*)
+            REPOSITORY="${option#*=}"
+            shift
+            ;;
+        --help|--info|--h)
+            CMD=`basename $0`
+            echo "$CMD [options] <release>"
+            echo "Deploys hyperion to kubernetes"
+            echo "  --help                  This help"
+            echo "  --dev                   Install to a development kubernetes cluster (assumes project checked out under /home)"
+            echo "  -b, --beamline=BEAMLINE Overrides the BEAMLINE environment variable with the given beamline"
+            echo "  --repository=REPOSITORY Override the repository to fetch the image from"
+            exit 0
+            ;;
+        -*|--*)
+            echo "Unknown option ${option}. Use --help for info on option usage."
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z $BEAMLINE ]]; then
+  echo "BEAMLINE not set and -b not specified"
+  exit 1
+fi
+
+RELEASE=$1
+
+if [[ -z $RELEASE ]]; then
+  echo "Release must be specified"
+  exit 1
+fi
+
+HELM_OPTIONS=""
+PROJECTDIR=$(readlink -e $(dirname $0)/../..)
+
+if [[ -n $REPOSITORY ]]; then
+  HELM_OPTIONS+="--set hyperion.imageRepository=$REPOSITORY "
+fi
+
+if [[ -n $DEV ]]; then
+  GID=`id -g`
+  SUPPLEMENTAL_GIDS=37904
+  HELM_OPTIONS+="--set \
+hyperion.dev=true,\
+hyperion.runAsUser=$EUID,\
+hyperion.runAsGroup=$GID,\
+hyperion.supplementalGroups=[$SUPPLEMENTAL_GIDS],\
+hyperion.logDir=/project/tmp,\
+hyperion.projectDir=$PROJECTDIR \
+--replace "
+  mkdir -p $PROJECTDIR/tmp
+fi
+
+helm install $HELM_OPTIONS $RELEASE $PROJECTDIR/helmchart

--- a/utility_scripts/docker/entrypoint.sh
+++ b/utility_scripts/docker/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -x
+# Entry point for the production docker image that launches the external callbacks
+# as well as the main server
+
+for option in "$@"; do
+    case $option in
+        --skip-startup-connection)
+            SKIP_STARTUP_CONNECTION=true
+            ;;
+        --dev)
+            IN_DEV=true
+            ;;
+        --verbose-event-logging)
+            VERBOSE_EVENT_LOGGING=true
+            ;;
+        --external-callbacks)
+            EXTERNAL_CALLBACK_SERVICE=true
+            ;;
+
+        --help|--info|--h)
+            echo "Arguments:"
+            echo "  --dev start in development mode without external callbacks"
+            exit 0
+            ;;
+        -*|--*)
+            echo "Unknown option ${option}. Use --help for info on option usage."
+            exit 1
+            ;;
+    esac
+done
+
+RELATIVE_SCRIPT_DIR=$( dirname -- "$0"; )
+cd ${RELATIVE_SCRIPT_DIR}
+
+echo "$(date) Logging to $HYPERION_LOG_DIR"
+mkdir -p $HYPERION_LOG_DIR
+start_log_path=$HYPERION_LOG_DIR/start_log.log
+callback_start_log_path=$HYPERION_LOG_DIR/callback_start_log.log
+
+#Add future arguments here
+declare -A h_only_args=(        ["SKIP_STARTUP_CONNECTION"]="$SKIP_STARTUP_CONNECTION"
+                                ["VERBOSE_EVENT_LOGGING"]="$VERBOSE_EVENT_LOGGING"
+                                ["EXTERNAL_CALLBACK_SERVICE"]="$EXTERNAL_CALLBACK_SERVICE" )
+declare -A h_only_arg_strings=( ["SKIP_STARTUP_CONNECTION"]="--skip-startup-connection"
+                                ["VERBOSE_EVENT_LOGGING"]="--verbose-event-logging"
+                                ["EXTERNAL_CALLBACK_SERVICE"]="--external-callbacks")
+
+declare -A h_and_cb_args=( ["IN_DEV"]="$IN_DEV" )
+declare -A h_and_cb_arg_strings=( ["IN_DEV"]="--dev" )
+
+h_commands=()
+for i in "${!h_only_args[@]}"
+do
+    if [ "${h_only_args[$i]}" != false ]; then 
+        h_commands+="${h_only_arg_strings[$i]} ";
+    fi;
+done
+cb_commands=()
+for i in "${!h_and_cb_args[@]}"
+do
+    if [ "${h_and_cb_args[$i]}" != false ]; then 
+        h_commands+="${h_and_cb_arg_strings[$i]} ";
+        cb_commands+="${h_and_cb_arg_strings[$i]} ";
+    fi;
+done
+
+if [ "$EXTERNAL_CALLBACK_SERVICE" = true ]; then
+    hyperion-callbacks `echo $cb_commands;`>$callback_start_log_path 2>&1 &
+fi
+
+echo "$(date) Starting Hyperion..."
+hyperion `echo $h_commands;`>$start_log_path  2>&1

--- a/utility_scripts/docker/healthcheck.sh
+++ b/utility_scripts/docker/healthcheck.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Healthcheck script for the container image
+curl -f --head -X GET http://localhost:5005/status || exit 1

--- a/utility_scripts/docker/i03-compose.yml
+++ b/utility_scripts/docker/i03-compose.yml
@@ -1,0 +1,60 @@
+name: i03-hyperion
+services:
+  hyperion-common:
+    image: localhost/hyperion
+    pull_policy: never
+    expose:
+      - "5005"
+    volumes:
+      - type: bind
+        source: /dls_sw/i03
+        target: /dls_sw/i03
+        read-only: true
+      - type: bind
+        source: /dls_sw/apps
+        target: /dls_sw/apps
+        read-only: true
+      - type: bind
+        source: /dls_sw/dasc
+        target: /dls_sw/dasc
+        read-only: true
+    network_mode: "host"
+    annotations:
+      # Required in order to read config files readable by dls_dasc
+      - run.oci.keep_original_groups=1
+  hyperion:
+    extends:
+      service: hyperion-common
+    volumes:
+      - type: bind
+        source: /dls/i03
+        target: /dls/i03
+      - type: bind
+        source: /dls_sw/i03/logs
+        target: /dls_sw/i03/logs
+    environment:
+      BEAMLINE: i03
+      HYPERION_LOG_DIR: /dls_sw/i03/logs/bluesky
+      ZOCALO_GO_USER: gda2
+      ZOCALO_GO_HOSTNAME: i03-control
+      ZOCALO_CONFIG: /dls_sw/apps/zocalo/live/configuration.yaml
+      ISPYB_CONFIG_PATH: /dls_sw/dasc/mariadb/credentials/ispyb-hyperion-i03.cfg
+    command: [ "--external-callbacks" ]
+  hyperion-dev:
+    extends:
+      service: hyperion-common
+    volumes:
+      # Bind some source folders for easier debugging
+      - type: bind
+        source: ../../src
+        target: /project/src
+      - type: bind
+        source: ../../utility_scripts
+        target: /project/utility_scripts
+      - type: bind
+        source: ../../tests
+        target: /project/tests
+    environment:
+      HYPERION_LOG_DIR: /tmp/dev
+    entrypoint: [ "/bin/bash" ]
+    


### PR DESCRIPTION
* New build_docker_image.sh script to build an image on the cli
* New run_in_podman.sh script to run the image from podman
* Github CI workflow to build container image on release and manual execution and push to GHCR registry
* Helm charts to deploy container images to kubernetes
* Hyperion now has --version option to report the current version
* The current version is now set automatically on pip install

Fixes #1367 #1403 

These changes are still pending scicomp request SCHD-5532 to create the required user for kubernetes on i03.
There will also need to be some changes to GDA restart_hyperion() logic which are TBD

Link to dodal PR (if required): N/A

(remember to update `setup.cfg` with the dodal commit tag if you need it for tests to pass!)

### To test:
* Hyperion should still build
* Releases should now build, tag and push container images with :latest and :<version> tags
* Hyperion should still work as normal in non-containerised deployment
* `hyperion --version` should now print the version of hyperion
* It should be possible to run a dev image of hyperion in podman locally
* It should be possible to run a dev image of hyperion in kubernetes (modulo non-availabililty of some PVs outside of beamline that prevent instantiation) and log into the console via k8s terminal
* It should be possible to deploy production in k8s (once service account with permissions created as above)
