### PR TITLE
Unpin dodal before release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a4
     blueapi >= 0.4.3-rc1
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@3c2a002562659eea342e770e967678acd0e9ddfa
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Unpins the dodal dependency in setup.cfg so that it pulls from main rather than a PR commit hash
