### PR TITLE
1517 fix panda issues discovered during testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a4
     blueapi >= 0.4.3-rc1
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@3f127b8bafd99e78a2dd54f8f1a0d5a3c77d26e7
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     ophyd-async >= 0.3a5
     bluesky >= 1.13.0a4
     blueapi >= 0.4.3-rc1
-    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git
+    dls-dodal @ git+https://github.com/DiamondLightSource/dodal.git@3f127b8bafd99e78a2dd54f8f1a0d5a3c77d26e7
 
 [options.entry_points]
 console_scripts =

--- a/src/hyperion/device_setup_plans/setup_panda.py
+++ b/src/hyperion/device_setup_plans/setup_panda.py
@@ -21,7 +21,6 @@ from hyperion.log import LOGGER
 
 MM_TO_ENCODER_COUNTS = 200000
 GENERAL_TIMEOUT = 60
-DETECTOR_TRIGGER_WIDTH = 1e-4
 TICKS_PER_MS = 1000  # Panda sequencer prescaler will be set to us
 
 
@@ -165,9 +164,7 @@ def setup_panda_for_flyscan(
         wait=True,
     )
 
-    yield from bps.abs_set(
-        panda.pulse[1].width, DETECTOR_TRIGGER_WIDTH, group="panda-config"
-    )
+    yield from bps.abs_set(panda.pulse[1].width, exposure_time_s, group="panda-config")
 
     exposure_distance_mm = sample_velocity_mm_per_s * exposure_time_s
 

--- a/src/hyperion/device_setup_plans/setup_panda.py
+++ b/src/hyperion/device_setup_plans/setup_panda.py
@@ -1,4 +1,4 @@
-import os
+from datetime import datetime
 from enum import Enum
 from importlib import resources
 from pathlib import Path
@@ -209,18 +209,12 @@ def disarm_panda_for_gridscan(panda, group="disarm_panda_gridscan") -> MsgGenera
     yield from bps.wait(group=group, timeout=GENERAL_TIMEOUT)
 
 
-def set_and_create_panda_directory(panda_directory: Path) -> MsgGenerator:
-    """Updates and creates the panda subdirectory which is used by the PandA's PCAP.
-    See https://github.com/DiamondLightSource/hyperion/issues/1385 for a better long
-    term solution.
-    """
+def set_panda_directory(panda_directory: Path) -> MsgGenerator:
+    """Updates the root folder which is used by the PandA's PCAP."""
 
-    if not os.path.isdir(panda_directory):
-        LOGGER.debug(f"Creating PandA PCAP subdirectory at {panda_directory}")
-        # Assumes we have permissions, which should be true on Hyperion for now
-        os.makedirs(panda_directory)
+    suffix = datetime.now().strftime("_%Y%m%d%H%M%S")
 
     async def set_panda_dir():
-        await get_directory_provider().update(directory=panda_directory)
+        await get_directory_provider().update(directory=panda_directory, suffix=suffix)
 
     yield from bps.wait_for([set_panda_dir])

--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -56,7 +56,7 @@ from hyperion.device_setup_plans.read_hardware_for_setup import (
 )
 from hyperion.device_setup_plans.setup_panda import (
     disarm_panda_for_gridscan,
-    set_and_create_panda_directory,
+    set_panda_directory,
     setup_panda_for_flyscan,
 )
 from hyperion.device_setup_plans.setup_zebra import (
@@ -521,8 +521,7 @@ def _panda_triggering_setup(
     )
 
     directory_provider_root = Path(parameters.storage_directory)
-
-    yield from set_and_create_panda_directory(directory_provider_root)
+    yield from set_panda_directory(directory_provider_root)
 
     yield from setup_panda_for_flyscan(
         fgs_composite.panda,

--- a/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/flyscan_xray_centre_plan.py
@@ -520,9 +520,9 @@ def _panda_triggering_setup(
         time_between_x_steps_ms,
     )
 
-    panda_directory = Path(parameters.storage_directory, "panda")
+    directory_provider_root = Path(parameters.storage_directory)
 
-    yield from set_and_create_panda_directory(panda_directory)
+    yield from set_and_create_panda_directory(directory_provider_root)
 
     yield from setup_panda_for_flyscan(
         fgs_composite.panda,

--- a/tests/unit_tests/device_setup_plans/test_setup_panda.py
+++ b/tests/unit_tests/device_setup_plans/test_setup_panda.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from bluesky.plan_stubs import null
 from bluesky.run_engine import RunEngine
-from bluesky.simulators import RunEngineSimulator
+from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
 from dodal.common.types import UpdatingDirectoryProvider
 from dodal.devices.fast_grid_scan import PandAGridScanParams
 from ophyd_async.panda import SeqTrigger
@@ -124,6 +124,13 @@ def test_setup_panda_correctly_configures_table(
     msgs = [
         msg for msg in msgs if not msg.kwargs.get("group", "").startswith("load-phase")
     ]
+
+    assert_message_and_return_remaining(
+        msgs,
+        lambda msg: msg.command == "set"
+        and msg.obj.name == "panda-pulse-1-width"
+        and msg.args[0] == exposure_time_s,
+    )
 
     table_msg = [
         msg

--- a/tests/unit_tests/device_setup_plans/test_setup_panda.py
+++ b/tests/unit_tests/device_setup_plans/test_setup_panda.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from datetime import datetime
 from typing import NamedTuple
 from unittest.mock import MagicMock, patch
 
@@ -7,13 +7,14 @@ import pytest
 from bluesky.plan_stubs import null
 from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator
+from dodal.common.types import UpdatingDirectoryProvider
 from dodal.devices.fast_grid_scan import PandAGridScanParams
 from ophyd_async.panda import SeqTrigger
 
 from hyperion.device_setup_plans.setup_panda import (
     MM_TO_ENCODER_COUNTS,
     disarm_panda_for_gridscan,
-    set_and_create_panda_directory,
+    set_panda_directory,
     setup_panda_for_flyscan,
 )
 
@@ -220,15 +221,18 @@ def test_disarm_panda_disables_correct_blocks(sim_run_engine):
     assert num_of_waits == 1
 
 
-def test_set_and_create_panda_directory(tmp_path, RE):
-    with patch(
-        "hyperion.device_setup_plans.setup_panda.os.path.isdir", return_value=False
-    ), patch("hyperion.device_setup_plans.setup_panda.os.makedirs") as mock_makedir:
-        RE(set_and_create_panda_directory(Path(tmp_path)))
-        mock_makedir.assert_called_once()
+@patch("hyperion.device_setup_plans.setup_panda.get_directory_provider")
+@patch("hyperion.device_setup_plans.setup_panda.datetime", spec=datetime)
+def test_set_panda_directory(
+    mock_datetime, mock_get_directory_provider: MagicMock, tmp_path, RE
+):
+    mock_directory_provider = MagicMock(spec=UpdatingDirectoryProvider)
+    mock_datetime.now = MagicMock(
+        return_value=datetime.fromisoformat("2024-08-11T15:59:23")
+    )
+    mock_get_directory_provider.return_value = mock_directory_provider
 
-    with patch(
-        "hyperion.device_setup_plans.setup_panda.os.path.isdir", return_value=True
-    ), patch("hyperion.device_setup_plans.setup_panda.os.makedirs") as mock_makedir:
-        RE(set_and_create_panda_directory(Path(tmp_path)))
-        mock_makedir.assert_not_called()
+    RE(set_panda_directory(tmp_path))
+    mock_directory_provider.update.assert_called_with(
+        directory=tmp_path, suffix="_20240811155923"
+    )

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -895,7 +895,7 @@ class TestFlyscanXrayCentrePlan:
         mock_parent.assert_has_calls([call.disarm(), call.run_end(0), call.run_end(0)])
 
     @patch(
-        "hyperion.experiment_plans.flyscan_xray_centre_plan.set_and_create_panda_directory",
+        "hyperion.experiment_plans.flyscan_xray_centre_plan.set_panda_directory",
         side_effect=_custom_msg("set_panda_directory"),
     )
     @patch(
@@ -912,7 +912,7 @@ class TestFlyscanXrayCentrePlan:
     )
     def test_flyscan_xray_centre_sets_directory_stages_arms_disarms_unstages_the_panda(
         self,
-        mock_set_and_create_panda_directory: MagicMock,
+        mock_set_panda_directory: MagicMock,
         done_status: Status,
         fgs_composite_with_panda_pcap: FlyScanXRayCentreComposite,
         fgs_params_use_panda: ThreeDGridScan,
@@ -927,7 +927,7 @@ class TestFlyscanXrayCentrePlan:
             flyscan_xray_centre(fgs_composite_with_panda_pcap, fgs_params_use_panda)
         )
 
-        mock_set_and_create_panda_directory.assert_called_with(
+        mock_set_panda_directory.assert_called_with(
             Path("/tmp/dls/i03/data/2024/cm31105-4/xraycentring/123456")
         )
 

--- a/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_flyscan_xray_centre_plan.py
@@ -1,5 +1,6 @@
 import random
 import types
+from pathlib import Path
 from typing import Tuple
 from unittest.mock import DEFAULT, MagicMock, call, patch
 
@@ -895,7 +896,7 @@ class TestFlyscanXrayCentrePlan:
 
     @patch(
         "hyperion.experiment_plans.flyscan_xray_centre_plan.set_and_create_panda_directory",
-        new=MagicMock(side_effect=_custom_msg("set_panda_directory")),
+        side_effect=_custom_msg("set_panda_directory"),
     )
     @patch(
         "hyperion.device_setup_plans.setup_panda.arm_panda_for_gridscan",
@@ -911,6 +912,7 @@ class TestFlyscanXrayCentrePlan:
     )
     def test_flyscan_xray_centre_sets_directory_stages_arms_disarms_unstages_the_panda(
         self,
+        mock_set_and_create_panda_directory: MagicMock,
         done_status: Status,
         fgs_composite_with_panda_pcap: FlyScanXRayCentreComposite,
         fgs_params_use_panda: ThreeDGridScan,
@@ -923,6 +925,10 @@ class TestFlyscanXrayCentrePlan:
 
         msgs = sim_run_engine.simulate_plan(
             flyscan_xray_centre(fgs_composite_with_panda_pcap, fgs_params_use_panda)
+        )
+
+        mock_set_and_create_panda_directory.assert_called_with(
+            Path("/tmp/dls/i03/data/2024/cm31105-4/xraycentring/123456")
         )
 
         msgs = assert_message_and_return_remaining(


### PR DESCRIPTION
Fixes #1517

Link to dodal PR (if required): DiamondLightSource/dodal#742

* The pulse block output pulse width should now be the same as the exposure time
* The pcap file name should now be unique (appended with the current timestamp)
* The extra 'panda' subdirectory should no longer be created
* Tests should still pass