### PR TITLE
Removed some references to ophyd

### DIFF
--- a/tests/system_tests/experiment_plans/test_fgs_plan.py
+++ b/tests/system_tests/experiment_plans/test_fgs_plan.py
@@ -14,7 +14,7 @@ from dodal.common.beamlines.beamline_parameters import (
 )
 from dodal.devices.aperturescatterguard import AperturePositions
 from dodal.devices.smargon import Smargon
-from ophyd.status import Status
+from ophyd.sim import NullStatus
 from ophyd_async.core import set_mock_value
 
 from hyperion.device_setup_plans.read_hardware_for_setup import (
@@ -116,8 +116,8 @@ async def fxc_composite():
     )
     composite.eiger.cam.manual_trigger.put("Yes")
     composite.eiger.odin.check_odin_initialised = lambda: (True, "")
-    composite.eiger.stage = MagicMock(return_value=Status(done=True, success=True))
-    composite.eiger.unstage = MagicMock(return_value=Status(done=True, success=True))
+    composite.eiger.stage = MagicMock(return_value=NullStatus())
+    composite.eiger.unstage = MagicMock(return_value=NullStatus())
 
     set_mock_value(composite.xbpm_feedback.pos_ok, True)
     set_mock_value(composite.xbpm_feedback.pos_stable, True)

--- a/tests/unit_tests/experiment_plans/conftest.py
+++ b/tests/unit_tests/experiment_plans/conftest.py
@@ -9,7 +9,7 @@ from dodal.devices.oav.oav_detector import OAVConfigParams
 from dodal.devices.synchrotron import SynchrotronMode
 from dodal.devices.zocalo import ZocaloResults, ZocaloTrigger
 from event_model import Event
-from ophyd.sim import make_fake_device
+from ophyd_async.core import DeviceCollector
 from ophyd_async.core.async_status import AsyncStatus
 
 from hyperion.external_interaction.callbacks.common.callback_util import (
@@ -181,13 +181,15 @@ def fake_read(obj, initial_positions, _):
 @pytest.fixture
 def simple_beamline(detector_motion, oav, smargon, synchrotron, test_config_files, dcm):
     magic_mock = MagicMock(autospec=True)
+
+    with DeviceCollector(mock=True):
+        magic_mock.zocalo = ZocaloResults()
+        magic_mock.zebra_fast_grid_scan = ZebraFastGridScan("preifx", "fake_fgs")
+
     magic_mock.oav = oav
     magic_mock.smargon = smargon
     magic_mock.detector_motion = detector_motion
-    magic_mock.zocalo = make_fake_device(ZocaloResults)()
     magic_mock.dcm = dcm
-    scan = make_fake_device(ZebraFastGridScan)("prefix", name="fake_fgs")
-    magic_mock.zebra_fast_grid_scan = scan
     magic_mock.synchrotron = synchrotron
     oav.zoom_controller.frst.set("7.5x")
     oav.parameters = OAVConfigParams(

--- a/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
+++ b/tests/unit_tests/experiment_plans/test_wait_for_robot_load_then_centre.py
@@ -7,11 +7,10 @@ from bluesky.run_engine import RunEngine
 from bluesky.simulators import RunEngineSimulator, assert_message_and_return_remaining
 from bluesky.utils import Msg
 from dodal.devices.aperturescatterguard import AperturePositions
-from dodal.devices.eiger import EigerDetector
 from dodal.devices.oav.oav_detector import OAV
-from dodal.devices.smargon import Smargon, StubPosition
+from dodal.devices.smargon import StubPosition
 from dodal.devices.webcam import Webcam
-from ophyd.sim import NullStatus, instantiate_fake_device
+from ophyd.sim import NullStatus
 from ophyd_async.core import set_mock_value
 
 from hyperion.experiment_plans.robot_load_then_centre_plan import (
@@ -30,7 +29,7 @@ from ...conftest import raw_params_from_file
 
 @pytest.fixture
 def robot_load_composite(
-    smargon, dcm, robot, aperture_scatterguard, oav, webcam, thawer, lower_gonio
+    smargon, dcm, robot, aperture_scatterguard, oav, webcam, thawer, lower_gonio, eiger
 ) -> RobotLoadThenCentreComposite:
     composite: RobotLoadThenCentreComposite = MagicMock()
     composite.smargon = smargon
@@ -44,6 +43,7 @@ def robot_load_composite(
     composite.webcam = webcam
     composite.lower_gonio = lower_gonio
     composite.thawer = thawer
+    composite.eiger = eiger
     return composite
 
 
@@ -131,6 +131,7 @@ def test_robot_load_then_centre_doesnt_set_energy_if_not_specified_and_current_e
     robot_load_then_centre_params_no_energy: RobotLoadThenCentre,
     sim_run_engine: RunEngineSimulator,
 ):
+    robot_load_composite.eiger.set_detector_parameters = MagicMock()
     sim_run_engine.add_handler(
         "read",
         lambda msg: {"dcm-energy_in_kev": {"value": 11.105}},
@@ -153,9 +154,6 @@ def run_simulating_smargon_wait(
     total_disabled_reads,
     sim_run_engine: RunEngineSimulator,
 ):
-    robot_load_composite.smargon = instantiate_fake_device(Smargon, name="smargon")
-    robot_load_composite.eiger = instantiate_fake_device(EigerDetector, name="eiger")
-
     num_of_reads = 0
 
     def return_not_disabled_after_reads(_):


### PR DESCRIPTION
Remove a few references to ophyd. Most of what's left should be those needed for devices that are still ophyd or `NullStatus`, which will need to think of a clean replacement for

### To test:
1. Confirm tests still pass
